### PR TITLE
Script output should be usefull with pipe or redirection

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -47,7 +47,7 @@ _logger() {
     shift
     test -z "$SCRIPT_NAME" && SCRIPT_NAME=$(basename $0)
     builtin echo "$*" | /usr/bin/logger -t "[CIS_Hardening] $SCRIPT_NAME" -p "user.info"
-    test -t 1 && cecho $COLOR "$SCRIPT_NAME $*"
+    cecho $COLOR "$SCRIPT_NAME $*"
 }
 
 cecho () {


### PR DESCRIPTION
with actual script if we execute :
`bin/hardening.sh --audit 2>/dev/null | grep KO`
this doesn't work and all tests appear " failed "

the file lib/main.sh contain a test that hide echo if it's not a terminal

I think the user should choose if we want process it (with pipe or IO redirection) and how
so you should remove this test.