### PR TITLE
[10.1.3] set the good value for $OPTIONS

### DIFF
--- a/bin/hardening/10.1.3_set_password_exp_warning_days.sh
+++ b/bin/hardening/10.1.3_set_password_exp_warning_days.sh
@@ -12,7 +12,7 @@ set -e # One error, it's over
 set -u # One variable unset, it's over
 
 PACKAGE='login'
-OPTIONS='PASS_MIN_DAYS=7'
+OPTIONS='PASS_WARN_AGE=7'
 FILE='/etc/login.defs'
 
 # This function will be called if the script status is on enabled / audit mode


### PR DESCRIPTION
Problem: 10.1.2 and 10.1.3 scripts are identical (except for the description).

The "option" verified in 10.1.3 is the same as in 10.1.2 : PASS_MIN_DAYS. It should be PASS_WARN_AGE.