### PR TITLE
Proposal to remove bc deps

### DIFF
--- a/bin/hardening.sh
+++ b/bin/hardening.sh
@@ -190,23 +190,6 @@ fi
 
 if [ "$BATCH_MODE" ]; then MACHINE_LOG_LEVEL=3; fi
 
-#
-# Math functions
-#
-
-function div() {
-    local _d=${3:-2}
-    local _n=0000000000
-    _n=${_n:0:$_d}
-    if (($2 == 0)); then
-        echo "N.A"
-        return
-    fi
-    local _r=$(($1$_n / $2))
-    _r=${_r:0:-$_d}.${_r: -$_d}
-    echo $_r
-}
-
 # If --allow-service-list is specified, don't run anything, just list the supported services
 if [ "$ALLOW_SERVICE_LIST" = 1 ]; then
     declare -a HARDENING_EXCEPTIONS_LIST

--- a/bin/hardening.sh
+++ b/bin/hardening.sh
@@ -190,6 +190,23 @@ fi
 
 if [ "$BATCH_MODE" ]; then MACHINE_LOG_LEVEL=3; fi
 
+#
+# Math functions
+#
+
+function div {
+    local _d=${3:-2}
+    local _n=0000000000
+    _n=${_n:0:$_d}
+    if (($2 == 0)); then
+        echo "N.A"
+        return
+    fi
+    local _r=$(($1$_n / $2))
+    _r=${_r:0:-$_d}.${_r: -$_d}
+    echo $_r
+}
+
 # If --allow-service-list is specified, don't run anything, just list the supported services
 if [ "$ALLOW_SERVICE_LIST" = 1 ]; then
     declare -a HARDENING_EXCEPTIONS_LIST
@@ -294,7 +311,7 @@ if [ "$BATCH_MODE" ]; then
     BATCH_SUMMARY+="RUN_CHECKS:${TOTAL_TREATED_CHECKS:-0} "
     BATCH_SUMMARY+="TOTAL_CHECKS_AVAIL:${TOTAL_CHECKS:-0}"
     if [ "$TOTAL_TREATED_CHECKS" != 0 ]; then
-        CONFORMITY_PERCENTAGE=$(bc -l <<<"scale=2; ($PASSED_CHECKS/$TOTAL_TREATED_CHECKS) * 100")
+        CONFORMITY_PERCENTAGE=$(div $(($PASSED_CHECKS * 100)) $TOTAL_TREATED_CHECKS)
         BATCH_SUMMARY+=" CONFORMITY_PERCENTAGE:$(printf "%s" "$CONFORMITY_PERCENTAGE")"
     else
         BATCH_SUMMARY+=" CONFORMITY_PERCENTAGE:N.A" # No check runned, avoid division by 0
@@ -307,8 +324,8 @@ else
     printf "%30s [ %7s ]\n" "Total Passed Checks :" "$PASSED_CHECKS/$TOTAL_TREATED_CHECKS"
     printf "%30s [ %7s ]\n" "Total Failed Checks :" "$FAILED_CHECKS/$TOTAL_TREATED_CHECKS"
 
-    ENABLED_CHECKS_PERCENTAGE=$(bc -l <<<"scale=2; ($TOTAL_TREATED_CHECKS/$TOTAL_CHECKS) * 100")
-    CONFORMITY_PERCENTAGE=$(bc -l <<<"scale=2; ($PASSED_CHECKS/$TOTAL_TREATED_CHECKS) * 100")
+    ENABLED_CHECKS_PERCENTAGE=$(div $(($TOTAL_TREATED_CHECKS * 100)) $TOTAL_CHECKS)
+    CONFORMITY_PERCENTAGE=$(div $(($PASSED_CHECKS * 100)) $TOTAL_TREATED_CHECKS)
     printf "%30s %s %%\n" "Enabled Checks Percentage :" "$ENABLED_CHECKS_PERCENTAGE"
     if [ "$TOTAL_TREATED_CHECKS" != 0 ]; then
         printf "%30s %s %%\n" "Conformity Percentage :" "$CONFORMITY_PERCENTAGE"

--- a/bin/hardening.sh
+++ b/bin/hardening.sh
@@ -194,7 +194,7 @@ if [ "$BATCH_MODE" ]; then MACHINE_LOG_LEVEL=3; fi
 # Math functions
 #
 
-function div {
+function div() {
     local _d=${3:-2}
     local _n=0000000000
     _n=${_n:0:$_d}

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/ovh/debian-cis/
 
 Package: cis-hardening
 Architecture: all
-Depends: ${misc:Depends}, bc, patch
+Depends: ${misc:Depends}, patch
 Description: Suite of configurable scripts to audit or harden a Debian.
  Modular Debian security hardening scripts based on cisecurity.org
  ⟨cisecurity.org⟩ recommendations. We use it at OVH ⟨https://www.ovh.com⟩ to

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -112,3 +112,20 @@ sudo_wrapper() {
         crit "Not allowed to \"sudo -n $*\" "
     fi
 }
+
+#
+# Math functions
+#
+
+function div() {
+    local _d=${3:-2}
+    local _n=0000000000
+    _n=${_n:0:$_d}
+    if (($2 == 0)); then
+        echo "N.A"
+        return
+    fi
+    local _r=$(($1$_n / $2))
+    _r=${_r:0:-$_d}.${_r: -$_d}
+    echo $_r
+}

--- a/tests/docker/Dockerfile.debian10
+++ b/tests/docker/Dockerfile.debian10
@@ -7,7 +7,7 @@ LABEL description="This image is used to run tests"
 
 RUN groupadd -g 500 secaudit && useradd  -u 500 -g 500 -s /bin/bash secaudit && install -m 700 -o secaudit -g secaudit -d /home/secaudit
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y bc openssh-server sudo syslog-ng net-tools auditd
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server sudo syslog-ng net-tools auditd
 
 COPY --chown=500:500 . /opt/debian-cis/
 

--- a/tests/docker/Dockerfile.debian8
+++ b/tests/docker/Dockerfile.debian8
@@ -7,7 +7,7 @@ LABEL description="This image is used to run tests"
 
 RUN groupadd -g 500 secaudit && useradd  -u 500 -g 500 -s /bin/bash secaudit && install -m 700 -o secaudit -g secaudit -d /home/secaudit
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y bc openssh-server sudo syslog-ng net-tools auditd
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server sudo syslog-ng net-tools auditd
 
 COPY --chown=500:500 . /opt/debian-cis/
 

--- a/tests/docker/Dockerfile.debian9
+++ b/tests/docker/Dockerfile.debian9
@@ -7,7 +7,7 @@ LABEL description="This image is used to run tests"
 
 RUN groupadd -g 500 secaudit && useradd  -u 500 -g 500 -s /bin/bash secaudit && install -m 700 -o secaudit -g secaudit -d /home/secaudit
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y bc openssh-server sudo syslog-ng net-tools auditd
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server sudo syslog-ng net-tools auditd
 
 COPY --chown=500:500 . /opt/debian-cis/
 


### PR DESCRIPTION
In minimal environment (debian or alpine container by example) bc isn't packaged by default, 
if the script can work without hard dependance, this should be more portable

Specific feature : catch division by 0 and write N.A