### PR TITLE
default variable to avoid unbound variable

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -298,6 +298,7 @@ is_kernel_option_enabled() {
     if [ $# -ge 2 ]; then
         MODULE_NAME="$2"
     fi
+    RESULT=""
     if $SUDO_CMD [ -r "/proc/config.gz" ]; then
         RESULT=$($SUDO_CMD zgrep "^$KERNEL_OPTION=" /proc/config.gz) || :
     elif $SUDO_CMD [ -r "/boot/config-$(uname -r)" ]; then

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -295,15 +295,22 @@ is_service_enabled() {
 is_kernel_option_enabled() {
     local KERNEL_OPTION="$1"
     local MODULE_NAME=""
+    local RESULT=""
+
     if [ $# -ge 2 ]; then
         MODULE_NAME="$2"
     fi
-    RESULT=""
+
     if $SUDO_CMD [ -r "/proc/config.gz" ]; then
         RESULT=$($SUDO_CMD zgrep "^$KERNEL_OPTION=" /proc/config.gz) || :
     elif $SUDO_CMD [ -r "/boot/config-$(uname -r)" ]; then
         RESULT=$($SUDO_CMD grep "^$KERNEL_OPTION=" "/boot/config-$(uname -r)") || :
+    else
+        debug "No information about kernel found, you're probably in a container"
+        FNRET=127
+        return
     fi
+
     ANSWER=$(cut -d = -f 2 <<<"$RESULT")
     if [ "x$ANSWER" = "xy" ]; then
         debug "Kernel option $KERNEL_OPTION enabled"


### PR DESCRIPTION
in minimal environment test case an error "unbound variable" appear in function "is_kernel_option_enabled",
in fact this function expect `/proc/config.gz` or `/boot/config-$(uname -r)` but not always available

in my PR, error "unbound variable" message are backed by a default value