### PR TITLE
1.6.4_restrict_core_dumps fix path

### DIFF
--- a/bin/hardening/1.6.4_restrict_core_dumps.sh
+++ b/bin/hardening/1.6.4_restrict_core_dumps.sh
@@ -29,7 +29,7 @@ audit() {
     LIMIT_FILES=""
     if $SUDO_CMD [ -d "$LIMIT_DIR" ]; then
         for file in $($SUDO_CMD ls "$LIMIT_DIR"/*.conf 2>/dev/null); do
-            LIMIT_FILES="$LIMIT_FILES $LIMIT_DIR/$file"
+            LIMIT_FILES="$LIMIT_FILES $file"
         done
     fi
     debug "Files to search $LIMIT_FILE $LIMIT_FILES"


### PR DESCRIPTION
actual command (`ls`) return full path and incorrectly concat to `$LIMIT_DIR/` this MR fix that