### PR TITLE
variable not renamed (lib/utils.sh)

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -359,7 +359,7 @@ is_kernel_option_enabled() {
             fi
         fi
     else
-        if [ "$FILTER" != "" ]; then
+        if [ "$MODPROBE_FILTER" != "" ]; then
             DEF_MODULE="$($SUDO_CMD modprobe -n -v "$MODULE_NAME" 2>/dev/null | grep -E "$MODPROBE_FILTER" | xargs)"
         else
             DEF_MODULE="$($SUDO_CMD modprobe -n -v "$MODULE_NAME" 2>/dev/null | xargs)"


### PR DESCRIPTION
Following previous PR, a renaming wasn't correctly done, this PR fix that (fix #46)