### PR TITLE
6.2.9_users_valid_homedir add exception

### DIFF
--- a/bin/hardening/6.2.9_users_valid_homedir.sh
+++ b/bin/hardening/6.2.9_users_valid_homedir.sh
@@ -17,7 +17,7 @@ HARDENING_LEVEL=2
 # shellcheck disable=2034
 DESCRIPTION="Ensure users own their home directories"
 
-EXCEPTIONS=""
+EXCEPTIONS="/:systemd-coredump:root"
 
 ERRORS=0
 


### PR DESCRIPTION
Since Debian 10, systemd create an user :
```
$ grep systemd-core /etc/passwd
systemd-coredump:x:999:999:systemd Core Dumper:/:/sbin/nologin
```
(https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931850)

with `/` home dir, owner is `root` and id > 500 so break the rules, should be added to exception like in this PR