### PR TITLE
FIX(2.2.1.4): Validate debian default ntp config

### DIFF
--- a/bin/hardening/2.2.1.4_configure_ntp.sh
+++ b/bin/hardening/2.2.1.4_configure_ntp.sh
@@ -20,7 +20,7 @@ DESCRIPTION="Configure Network Time Protocol (ntp). Check restrict parameters an
 HARDENING_EXCEPTION=ntp
 
 PACKAGE='ntp'
-NTP_CONF_DEFAULT_PATTERN='^restrict -4 default (kod nomodify notrap nopeer noquery|ignore)'
+NTP_CONF_DEFAULT_PATTERN='^restrict -4 default (kod nomodify notrap nopeer noquery|kod notrap nomodify nopeer noquery|ignore)'
 NTP_CONF_FILE='/etc/ntp.conf'
 NTP_INIT_PATTERN='RUNASUSER=ntp'
 NTP_INIT_FILE='/etc/init.d/ntp'


### PR DESCRIPTION
CIS benchmark states in §2.2.1.4 that ntp config should contain

```
restrict -4 default kod nomodify notrap nopeer noquery
```

However, debian's default config file has

```
restrict -4 default kod notrap nomodify nopeer noquery limited
```

Which is the exact same flags (with the addition of limited) but in a different order.

So debian default ntp configuration is compliant with this CIS rule but check fails.

This PR also validate NTP configuration with debian default flag order