### PR TITLE
Fix grub detection

### DIFF
--- a/bin/hardening/1.5.1_bootloader_ownership.sh
+++ b/bin/hardening/1.5.1_bootloader_ownership.sh
@@ -63,7 +63,7 @@ apply() {
 # This function will check config parameters required
 check_config() {
 
-    is_pkg_installed "grub-pc"
+    is_pkg_installed "grub-common"
     if [ "$FNRET" != 0 ]; then
         warn "Grub is not installed, not handling configuration"
         exit 2

--- a/bin/hardening/1.5.2_bootloader_password.sh
+++ b/bin/hardening/1.5.2_bootloader_password.sh
@@ -55,9 +55,9 @@ apply() {
 
 # This function will check config parameters required
 check_config() {
-    is_pkg_installed "grub-pc"
+    is_pkg_installed "grub-common"
     if [ "$FNRET" != 0 ]; then
-        warn "grub-pc is not installed, not handling configuration"
+        warn "Grub is not installed, not handling configuration"
         exit 2
     fi
     if [ "$FNRET" != 0 ]; then

--- a/bin/hardening/1.7.1.2_enable_apparmor.sh
+++ b/bin/hardening/1.7.1.2_enable_apparmor.sh
@@ -33,7 +33,7 @@ audit() {
     done
 
     if [ "$ERROR" = 0 ]; then
-        is_pkg_installed "grub-pc"
+        is_pkg_installed "grub-common"
         if [ "$FNRET" != 0 ]; then
             if [ "$IS_CONTAINER" -eq 1 ]; then
                 ok "Grub is not installed in container"


### PR DESCRIPTION
Grub detection for 1.5.1 and 1.5.2 are currently based on `grub-pc` package detection.

However, currently, OVH PCI VM default debian images and OVH baremetal systems both have no `grub-pc` package despite grub is installed and in use.

current grub installed packages from a baremetal system are:
- `grub-common`
- `grub-efi-amd64`
- `grub-efi-amd64-bin`
- `grub-efi-amd64-signed`
- `grub-legacy-ec2`
- `grub2-common`

This PR check grub presence by looking at `grub-common` package instead of `grub-pc` which should improve grub detection