### PR TITLE
Skip NTP and Chrony config check if they are not installed

### DIFF
--- a/bin/hardening/2.2.1.3_configure_chrony.sh
+++ b/bin/hardening/2.2.1.3_configure_chrony.sh
@@ -25,17 +25,11 @@ CONF_FILE='/etc/chrony/chrony.conf'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    is_pkg_installed "$PACKAGE"
+    does_pattern_exist_in_file "$CONF_FILE" "$CONF_DEFAULT_PATTERN"
     if [ "$FNRET" != 0 ]; then
-        crit "$PACKAGE is not installed!"
+        crit "$CONF_DEFAULT_PATTERN not found in $CONF_FILE"
     else
-        ok "$PACKAGE is installed, checking configuration"
-        does_pattern_exist_in_file "$CONF_FILE" "$CONF_DEFAULT_PATTERN"
-        if [ "$FNRET" != 0 ]; then
-            crit "$CONF_DEFAULT_PATTERN not found in $CONF_FILE"
-        else
-            ok "$CONF_DEFAULT_PATTERN found in $CONF_FILE"
-        fi
+        ok "$CONF_DEFAULT_PATTERN found in $CONF_FILE"
     fi
 }
 
@@ -46,7 +40,11 @@ apply() {
 
 # This function will check config parameters required
 check_config() {
-    :
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        warn "$PACKAGE is not installed, not handling configuration"
+        exit 2
+    fi
 }
 
 # Source Root Dir Parameter

--- a/bin/hardening/2.2.1.4_configure_ntp.sh
+++ b/bin/hardening/2.2.1.4_configure_ntp.sh
@@ -27,23 +27,17 @@ NTP_INIT_FILE='/etc/init.d/ntp'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    is_pkg_installed "$PACKAGE"
+    does_pattern_exist_in_file "$NTP_CONF_FILE" "$NTP_CONF_DEFAULT_PATTERN"
     if [ "$FNRET" != 0 ]; then
-        crit "$PACKAGE is not installed!"
+        crit "$NTP_CONF_DEFAULT_PATTERN not found in $NTP_CONF_FILE"
     else
-        ok "$PACKAGE is installed, checking configuration"
-        does_pattern_exist_in_file "$NTP_CONF_FILE" "$NTP_CONF_DEFAULT_PATTERN"
-        if [ "$FNRET" != 0 ]; then
-            crit "$NTP_CONF_DEFAULT_PATTERN not found in $NTP_CONF_FILE"
-        else
-            ok "$NTP_CONF_DEFAULT_PATTERN found in $NTP_CONF_FILE"
-        fi
-        does_pattern_exist_in_file "$NTP_INIT_FILE" "^$NTP_INIT_PATTERN"
-        if [ "$FNRET" != 0 ]; then
-            crit "$NTP_INIT_PATTERN not found in $NTP_INIT_FILE"
-        else
-            ok "$NTP_INIT_PATTERN found in $NTP_INIT_FILE"
-        fi
+        ok "$NTP_CONF_DEFAULT_PATTERN found in $NTP_CONF_FILE"
+    fi
+    does_pattern_exist_in_file "$NTP_INIT_FILE" "^$NTP_INIT_PATTERN"
+    if [ "$FNRET" != 0 ]; then
+        crit "$NTP_INIT_PATTERN not found in $NTP_INIT_FILE"
+    else
+        ok "$NTP_INIT_PATTERN found in $NTP_INIT_FILE"
     fi
 }
 
@@ -77,7 +71,11 @@ apply() {
 
 # This function will check config parameters required
 check_config() {
-    :
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        warn "$PACKAGE is not installed, not handling configuration"
+        exit 2
+    fi
 }
 
 # Source Root Dir Parameter


### PR DESCRIPTION
CIS benchmark states about chrony (resp. ntp) configuration:

> This recommendation only applies if chrony (resp. ntp) is in use on the system.

This PR complies to this statement but skipping config check for chrony and ntp if they are not installed on the system.

Fixes #117 