### PR TITLE
Allow grub.cfg permission to be 600

### DIFF
--- a/bin/hardening/1.5.1_bootloader_ownership.sh
+++ b/bin/hardening/1.5.1_bootloader_ownership.sh
@@ -23,6 +23,7 @@ FILE='/boot/grub/grub.cfg'
 USER='root'
 GROUP='root'
 PERMISSIONS='400'
+PERMISSIONSOK='400 600'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
@@ -33,7 +34,7 @@ audit() {
         crit "$FILE ownership was not set to $USER:$GROUP"
     fi
 
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
+    has_file_one_of_permissions "$FILE" "$PERMISSIONSOK"
     if [ "$FNRET" = 0 ]; then
         ok "$FILE has correct permissions"
     else
@@ -51,7 +52,7 @@ apply() {
         chown "$USER":"$GROUP" "$FILE"
     fi
 
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
+    has_file_one_of_permissions "$FILE" "$PERMISSIONSOK"
     if [ "$FNRET" = 0 ]; then
         ok "$FILE has correct permissions"
     else


### PR DESCRIPTION
CIS Benchmark §1.5.1 states:

> Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them.

Nothing in this paragraph prevents this file to be user-writable by owner `root`, only read and write permission by group and other are forbidden.

debian's `update-grub` script creates `grub.cfg` file with mode `0600` which is compliant with CIS benchmark recommandation but fails `debian-cis` check.

This PR allows `grub.cfg`  file to have `0600` permission as well as `0400` and don't consider `0600` to be faulty anymore.