### PR TITLE
Add homedir ownership exception for systemd-coredump

### DIFF
--- a/bin/hardening/6.2.9_users_valid_homedir.sh
+++ b/bin/hardening/6.2.9_users_valid_homedir.sh
@@ -17,7 +17,7 @@ HARDENING_LEVEL=2
 # shellcheck disable=2034
 DESCRIPTION="Ensure users own their home directories"
 
-EXCEPTIONS=""
+EXCEPTIONS="/:systemd-coredump:root"
 
 ERRORS=0
 


### PR DESCRIPTION
`systemd-coredump` is a debian/systemd system user whose homedir is `/` by default so this user doesn't comply with 6.2.9

However, this system user is disabled and having `/` as home directory is by design so this PR adds this as an exception.