### PR TITLE
Fix 3.4.2 audit rule

### DIFF
--- a/bin/hardening/3.4.2_disable_sctp.sh
+++ b/bin/hardening/3.4.2_disable_sctp.sh
@@ -28,7 +28,7 @@ audit() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_option_enabled "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_option_enabled "$KERNEL_OPTION" "$MODULE_NAME" "($MODULE_NAME|install)"
         if [ "$FNRET" = 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is enabled!"
         else


### PR DESCRIPTION
3.4.2 CIS detection example is `modprobe -n -v sctp | grep -E '(sctp|install)'`

`MODPROBE_FILTER` is necessary here because `sctp` module depends on `libcrc32c` module so even if it is disabled, `modprobe -n -v sctp` returns

```
insmod /lib/modules/4.19.0-18-cloud-amd64/kernel/lib/libcrc32c.ko 
install /bin/true
```

and detection fails

This PR fixes that behaviour by adding missing `MODPROBE_FILTER` to `is_kernel_option_enabled` call.