### PR TITLE
WIP: Add rsyslog checks

### DIFF
--- a/bin/hardening/4.2.1.1_install_rsyslog.sh
+++ b/bin/hardening/4.2.1.1_install_rsyslog.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 4.2.1.1 Ensure rsyslog is installed (Scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=3
+# shellcheck disable=2034
+DESCRIPTION="Install rsyslog to manage logs"
+
+PACKAGE='rsyslog'
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        crit "$PACKAGE is not installed!"
+    else
+        ok "$PACKAGE is installed"
+    fi
+}
+
+# This function will be called if the script status is on enabled mode
+apply() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" = 0 ]; then
+        ok "$PACKAGE is installed"
+    else
+        crit "$PACKAGE is absent, installing it"
+        apt_install "$PACKAGE"
+    fi
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi

--- a/bin/hardening/4.2.1.2_enable_rsyslog.sh
+++ b/bin/hardening/4.2.1.2_enable_rsyslog.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 4.2.1.2 Ensure rsyslog service is enabled (Scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=3
+# shellcheck disable=2034
+DESCRIPTION="Ensure rsyslog service is activated."
+
+PACKAGE='rsyslog'
+SERVICE_NAME="rsyslog"
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        crit "$PACKAGE is not installed!"
+    else
+        info "Checking if $SERVICE_NAME is enabled"
+        is_service_enabled "$SERVICE_NAME"
+        if [ "$FNRET" = 0 ]; then
+            ok "$SERVICE_NAME is enabled"
+        else
+            crit "$SERVICE_NAME is disabled"
+        fi
+    fi
+}
+
+# This function will be called if the script status is on enabled mode
+apply() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        crit "$PACKAGE is not installed!"
+    else
+        info "Checking if $SERVICE_NAME is enabled"
+        is_service_enabled "$SERVICE_NAME"
+        if [ "$FNRET" != 0 ]; then
+            info "Enabling $SERVICE_NAME"
+            update-rc.d "$SERVICE_NAME" remove >/dev/null 2>&1
+            update-rc.d "$SERVICE_NAME" defaults >/dev/null 2>&1
+        else
+            ok "$SERVICE_NAME is enabled"
+        fi
+    fi
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi

--- a/bin/hardening/4.2.1.3_configure_rsyslog.sh
+++ b/bin/hardening/4.2.1.3_configure_rsyslog.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 4.2.1.3 Configure /etc/rsyslog/rsyslog.conf (Not Scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=3
+# shellcheck disable=2034
+DESCRIPTION="Configure /etc/rsyslog/rsyslog.conf ."
+
+# shellcheck disable=2034
+SERVICE_NAME="rsyslog"
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    info "Ensure default and local facilities are preserved on the system"
+    info "No measure here, please review the file by yourself"
+}
+
+# This function will be called if the script status is on enabled mode
+apply() {
+    info "Ensure default and local facilities are preserved on the system"
+    info "No measure here, please review the file by yourself"
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi

--- a/bin/hardening/4.2.1.4_rsyslog_logfiles_perm.sh
+++ b/bin/hardening/4.2.1.4_rsyslog_logfiles_perm.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 4.2.1.4 Create and Set Permissions on rsyslog Log Files (Scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=3
+# shellcheck disable=2034
+DESCRIPTION="Create and set permissions on rsyslog logfiles."
+
+# Note: this is not exacly the same check as the one described in CIS PDF
+
+PACKAGE='rsyslog'
+# shellcheck disable=2016
+PATTERN='\$FileCreateMode[[:space:]]*0640'
+FILES_TO_SEARCH='/etc/rsyslog.conf /etc/rsyslog.d'
+PATTERN_TO_ADD='FileCreateMode 0640'
+FILE='/etc/rsyslog.conf'
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        crit "$PACKAGE is not installed!"
+    else
+        SEARCH_RES=0
+        for FILE_SEARCHED in $FILES_TO_SEARCH; do
+            if [ "$SEARCH_RES" = 1 ]; then break; fi
+            if test -d "$FILE_SEARCHED"; then
+                debug "$FILE_SEARCHED is a directory"
+                for file_in_dir in "$FILE_SEARCHED"/*; do
+                    [[ -e "$file_in_dir" ]] || break # handle the case of no file in dir
+                    does_pattern_exist_in_file "$file_in_dir" "^$PATTERN"
+                    if [ "$FNRET" != 0 ]; then
+                        debug "$PATTERN is not present in $file_in_dir"
+                    else
+                        ok "$PATTERN is present in $file_in_dir"
+                        SEARCH_RES=1
+                        break
+                    fi
+                done
+            else
+                does_pattern_exist_in_file "$FILE_SEARCHED" "^$PATTERN"
+                if [ "$FNRET" != 0 ]; then
+                    debug "$PATTERN is not present in $FILE_SEARCHED"
+                else
+                    ok "$PATTERN is present in $FILES_TO_SEARCH"
+                    SEARCH_RES=1
+                fi
+            fi
+        done
+        if [ "$SEARCH_RES" = 0 ]; then
+            crit "$PATTERN is not present in $FILES_TO_SEARCH"
+        fi
+    fi
+}
+
+# This function will be called if the script status is on enabled mode
+apply() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" = 0 ]; then
+        ok "$PACKAGE is installed"
+    else
+        crit "$PACKAGE is not installed, installing it"
+        apt_install "$PACKAGE"
+        info "Chcking $PACKAGE configuration"
+    fi
+    SEARCH_RES=0$
+    for FILE_SEARCHED in $FILES_TO_SEARCH; do
+        if [ "$SEARCH_RES" = 1 ]; then break; fi
+        if test -d "$FILE_SEARCHED"; then
+            debug "$FILE_SEARCHED is a directory"
+            for file_in_dir in "$FILE_SEARCHED"/*; do
+                [[ -e "$file_in_dir" ]] || break # handle the case of no file in dir
+                does_pattern_exist_in_file "$file_in_dir" "^$PATTERN"
+                if [ "$FNRET" != 0 ]; then
+                    debug "$PATTERN is not present in $file_in_dir"
+                else
+                    ok "$PATTERN is present in $file_in_dir"
+                    SEARCH_RES=1
+                    break
+                fi
+            done
+        else
+            does_pattern_exist_in_file "$FILE_SEARCHED" "^$PATTERN"
+            if [ "$FNRET" != 0 ]; then
+                debug "$PATTERN is not present in $FILE_SEARCHED"
+            else
+                ok "$PATTERN is present in $FILES_TO_SEARCH"
+                SEARCH_RES=1
+            fi
+        fi
+    done
+    if [ "$SEARCH_RES" = 0 ]; then
+        warn "$PATTERN is not present in $FILES_TO_SEARCH"
+        touch "$FILE"
+        add_end_of_file "$FILE" "$PATTERN_TO_ADD"
+    fi
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi

--- a/bin/hardening/4.2.1.5_rsyslog_remote_host.sh
+++ b/bin/hardening/4.2.1.5_rsyslog_remote_host.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 4.2.1.4 Create and Set Permissions on rsyslog Log Files (Scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=3
+# shellcheck disable=2034
+DESCRIPTION="Create and set permissions on rsyslog logfiles."
+
+# Note: this is not exacly the same check as the one described in CIS PDF
+
+PACKAGE='rsyslog'
+PATTERN='[^#](\s*\S+\s*)\s*action\(.*target='
+FILES_TO_SEARCH='/etc/rsyslog.conf /etc/rsyslog.d'
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        crit "$PACKAGE is not installed!"
+    else
+        SEARCH_RES=0
+        for FILE_SEARCHED in $FILES_TO_SEARCH; do
+            if [ "$SEARCH_RES" = 1 ]; then break; fi
+            if test -d "$FILE_SEARCHED"; then
+                debug "$FILE_SEARCHED is a directory"
+                for file_in_dir in "$FILE_SEARCHED"/*; do
+                    [[ -e "$file_in_dir" ]] || break # handle the case of no file in dir
+                    does_pattern_exist_in_file "$file_in_dir" "^$PATTERN"
+                    if [ "$FNRET" != 0 ]; then
+                        debug "$PATTERN is not present in $file_in_dir"
+                    else
+                        ok "$PATTERN is present in $file_in_dir"
+                        SEARCH_RES=1
+                        break
+                    fi
+                done
+            else
+                does_pattern_exist_in_file "$FILE_SEARCHED" "^$PATTERN"
+                if [ "$FNRET" != 0 ]; then
+                    debug "$PATTERN is not present in $FILE_SEARCHED"
+                else
+                    ok "$PATTERN is present in $FILES_TO_SEARCH"
+                    SEARCH_RES=1
+                fi
+            fi
+        done
+        if [ "$SEARCH_RES" = 0 ]; then
+            crit "$PATTERN is not present in $FILES_TO_SEARCH"
+        fi
+    fi
+}
+
+# This function will be called if the script status is on enabled mode
+apply() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" = 0 ]; then
+        ok "$PACKAGE is installed"
+    else
+        crit "$PACKAGE is not installed, installing it"
+        apt_install "$PACKAGE"
+        info "Chcking $PACKAGE configuration"
+    fi
+    SEARCH_RES=0$
+    for FILE_SEARCHED in $FILES_TO_SEARCH; do
+        if [ "$SEARCH_RES" = 1 ]; then break; fi
+        if test -d "$FILE_SEARCHED"; then
+            debug "$FILE_SEARCHED is a directory"
+            for file_in_dir in "$FILE_SEARCHED"/*; do
+                [[ -e "$file_in_dir" ]] || break # handle the case of no file in dir
+                does_pattern_exist_in_file "$file_in_dir" "^$PATTERN"
+                if [ "$FNRET" != 0 ]; then
+                    debug "$PATTERN is not present in $file_in_dir"
+                else
+                    ok "$PATTERN is present in $file_in_dir"
+                    SEARCH_RES=1
+                    break
+                fi
+            done
+        else
+            does_pattern_exist_in_file "$FILE_SEARCHED" "^$PATTERN"
+            if [ "$FNRET" != 0 ]; then
+                debug "$PATTERN is not present in $FILE_SEARCHED"
+            else
+                ok "$PATTERN is present in $FILES_TO_SEARCH"
+                SEARCH_RES=1
+            fi
+        fi
+    done
+    if [ "$SEARCH_RES" = 0 ]; then
+        warn "$PATTERN is not present in $FILES_TO_SEARCH"
+        warn "I cannot fix sending logs to remote host, configure rsyslog to send logs to remote host"
+    fi
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi

--- a/bin/hardening/4.2.1.6_remote_rsyslog_acl.sh
+++ b/bin/hardening/4.2.1.6_remote_rsyslog_acl.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 4.2.1.6 Ensure remote rsyslog messages are only accepted on designated log hosts. (Not Scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=3
+# shellcheck disable=2034
+DESCRIPTION="Configure rsyslog to accept remote syslog messages only on designated log hosts."
+
+# Note: this is not exacly the same check as the one described in CIS PDF
+
+PACKAGE='rsyslog'
+REMOTE_HOST=""
+# shellcheck disable=2016
+PATTERN='(\$ModLoad imtcp|\$InputTCPServerRun)'
+FILES_TO_SEARCH='/etc/rsyslog.conf /etc/rsyslog.d'
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" != 0 ]; then
+        crit "$PACKAGE is not installed!"
+    else
+        SEARCH_RES=0
+        for FILE_SEARCHED in $FILES_TO_SEARCH; do
+            if [ "$SEARCH_RES" = 1 ]; then break; fi
+            if test -d "$FILE_SEARCHED"; then
+                debug "$FILE_SEARCHED is a directory"
+                for file_in_dir in "$FILE_SEARCHED"/*; do
+                    [[ -e "$file_in_dir" ]] || break # handle the case of no file in dir
+                    does_pattern_exist_in_file "$file_in_dir" "^$PATTERN"
+                    if [ "$FNRET" != 0 ]; then
+                        debug "$PATTERN is not present in $file_in_dir"
+                    else
+                        ok "$PATTERN is present in $file_in_dir"
+                        SEARCH_RES=1
+                        break
+                    fi
+                done
+            else
+                does_pattern_exist_in_file "$FILE_SEARCHED" "^$PATTERN"
+                if [ "$FNRET" != 0 ]; then
+                    debug "$PATTERN is not present in $FILE_SEARCHED"
+                else
+                    ok "$PATTERN is present in $FILES_TO_SEARCH"
+                    SEARCH_RES=1
+                fi
+            fi
+        done
+        if [[ "$REMOTE_HOST" ]]; then
+            info "This is the remote host, checking that it only accepts logs from specified zone"
+            if [ "$SEARCH_RES" = 1 ]; then
+                ok "$PATTERN is present in $FILES_TO_SEARCH"
+            else
+                crit "$PATTERN is not present in $FILES_TO_SEARCH"
+            fi
+        else
+            info "This is the not the remote host checking that it doesn't accept remote logs"
+            if [ "$SEARCH_RES" = 1 ]; then
+                crit "$PATTERN is present in $FILES_TO_SEARCH"
+            else
+                ok "$PATTERN is not present in $FILES_TO_SEARCH"
+            fi
+        fi
+    fi
+}
+
+# This function will be called if the script status is on enabled mode
+apply() {
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" = 0 ]; then
+        ok "$PACKAGE is installed"
+    else
+        crit "$PACKAGE is not installed, installing it"
+        apt_install "$PACKAGE"
+        info "Chcking $PACKAGE configuration"
+    fi
+    SEARCH_RES=0$
+    for FILE_SEARCHED in $FILES_TO_SEARCH; do
+        if [ "$SEARCH_RES" = 1 ]; then break; fi
+        if test -d "$FILE_SEARCHED"; then
+            debug "$FILE_SEARCHED is a directory"
+            for file_in_dir in "$FILE_SEARCHED"/*; do
+                [[ -e "$file_in_dir" ]] || break # handle the case of no file in dir
+                does_pattern_exist_in_file "$file_in_dir" "^$PATTERN"
+                if [ "$FNRET" != 0 ]; then
+                    debug "$PATTERN is not present in $file_in_dir"
+                else
+                    ok "$PATTERN is present in $file_in_dir"
+                    SEARCH_RES=1
+                    break
+                fi
+            done
+        else
+            does_pattern_exist_in_file "$FILE_SEARCHED" "^$PATTERN"
+            if [ "$FNRET" != 0 ]; then
+                debug "$PATTERN is not present in $FILE_SEARCHED"
+            else
+                ok "$PATTERN is present in $FILES_TO_SEARCH"
+                SEARCH_RES=1
+            fi
+        fi
+    done
+    if [[ "$REMOTE_HOST" ]]; then
+        info "This is the remote host, checking that it only accepts logs from specified zone"
+        if [ "$SEARCH_RES" = 1 ]; then
+            ok "$PATTERN is present in $FILES_TO_SEARCH"
+        else
+            crit "$PATTERN is not present in $FILES_TO_SEARCH, setup the machine to receive the logs"
+        fi
+    else
+        info "This is the not the remote host checking that it doesn't accept remote logs"
+        if [ "$SEARCH_RES" = 1 ]; then
+            warn "$PATTERN is present in $FILES_TO_SEARCH, "
+        else
+            ok "$PATTERN is not present in $FILES_TO_SEARCH, setup the machine to deny remote logs"
+        fi
+    fi
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# This function will create the config file for this check with default values
+create_config() {
+    cat <<EOF
+status=audit
+# Set REMOTE_HOST to "true" if it's the remote host
+REMOTE_HOST=""
+EOF
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi


### PR DESCRIPTION
This PR adds 4.2.1.* checks for rsyslog  for systems that use rsyslog instead of syslog-ng

I have tested that having multiple tests for same paragraph number is working correctly, even with `--only` parameter of `hardening.sh` (both tests are selected and run)

Currently user should disable one of syslog-ng or rsyslog test for each number given both logging daemons are mutually exclusive.

Checklist:
- [x] implement rsyslog checks
- [ ] find a way to globally configure debian-cis with rsyslog or syslog-ng exclusively to avoid having to disable one of each check
- [ ] Implement tests

