### PR TITLE
Honor --set-log-level parameter

### DIFF
--- a/bin/hardening.sh
+++ b/bin/hardening.sh
@@ -299,19 +299,19 @@ for SCRIPT in $(find "$CIS_ROOT_DIR"/bin/hardening/ -name "*.sh" | sort -V); do
     info "Treating $SCRIPT"
     if [ "$CREATE_CONFIG" = 1 ]; then
         debug "$CIS_ROOT_DIR/bin/hardening/$SCRIPT --create-config-files-only"
-        "$SCRIPT" --create-config-files-only "$BATCH_MODE"
+        LOGLEVEL=$LOGLEVEL "$SCRIPT" --create-config-files-only "$BATCH_MODE"
     elif [ "$AUDIT" = 1 ]; then
         debug "$CIS_ROOT_DIR/bin/hardening/$SCRIPT --audit $SUDO_MODE $BATCH_MODE"
-        "$SCRIPT" --audit "$SUDO_MODE" "$BATCH_MODE"
+        LOGLEVEL=$LOGLEVEL "$SCRIPT" --audit "$SUDO_MODE" "$BATCH_MODE"
     elif [ "$AUDIT_ALL" = 1 ]; then
         debug "$CIS_ROOT_DIR/bin/hardening/$SCRIPT --audit-all $SUDO_MODE $BATCH_MODE"
-        "$SCRIPT" --audit-all "$SUDO_MODE" "$BATCH_MODE"
+        LOGLEVEL=$LOGLEVEL "$SCRIPT" --audit-all "$SUDO_MODE" "$BATCH_MODE"
     elif [ "$AUDIT_ALL_ENABLE_PASSED" = 1 ]; then
         debug "$CIS_ROOT_DIR/bin/hardening/$SCRIPT --audit-all $SUDO_MODE $BATCH_MODE"
-        "$SCRIPT" --audit-all "$SUDO_MODE" "$BATCH_MODE"
+        LOGLEVEL=$LOGLEVEL "$SCRIPT" --audit-all "$SUDO_MODE" "$BATCH_MODE"
     elif [ "$APPLY" = 1 ]; then
         debug "$CIS_ROOT_DIR/bin/hardening/$SCRIPT"
-        "$SCRIPT"
+        LOGLEVEL=$LOGLEVEL "$SCRIPT"
     fi
 
     SCRIPT_EXITCODE=$?

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -10,9 +10,16 @@ BATCH_OUTPUT=""
 status=""
 forcedstatus=""
 SUDO_CMD=""
+SAVED_LOGLEVEL=""
 
+if [ -n "${LOGLEVEL:-}" ]; then
+    SAVED_LOGLEVEL=$LOGLEVEL
+fi
 # shellcheck source=../etc/hardening.cfg
 [ -r "$CIS_ROOT_DIR"/etc/hardening.cfg ] && . "$CIS_ROOT_DIR"/etc/hardening.cfg
+if [ -n "$SAVED_LOGLEVEL" ]; then
+    LOGLEVEL=$SAVED_LOGLEVEL
+fi
 # shellcheck source=../lib/common.sh
 [ -r "$CIS_ROOT_DIR"/lib/common.sh ] && . "$CIS_ROOT_DIR"/lib/common.sh
 # shellcheck source=../lib/utils.sh


### PR DESCRIPTION
Currently, `LOGLEVEL` config option takes precedence over `--set-log-level` parameter.

This PR fixes that behaviour by passing `LOGLEVEL` value from `hardening.sh` to each check script.

Fixes #126 