### PR TITLE
FIX(1.7.1.4): don't abort script in case of unconfined processes

### DIFF
--- a/bin/hardening/1.7.1.4_enforcing_apparmor.sh
+++ b/bin/hardening/1.7.1.4_enforcing_apparmor.sh
@@ -32,8 +32,8 @@ audit() {
         fi
     done
     if [ "$ERROR" = 0 ]; then
-        RESULT_UNCONFINED=$($SUDO_CMD apparmor_status | grep "^0 processes are unconfined but have a profile defined")
-        RESULT_COMPLAIN=$($SUDO_CMD apparmor_status | grep "^0 profiles are in complain mode.")
+        RESULT_UNCONFINED=$($SUDO_CMD apparmor_status | grep "^0 processes are unconfined but have a profile defined" || true)
+        RESULT_COMPLAIN=$($SUDO_CMD apparmor_status | grep "^0 profiles are in complain mode." || true)
 
         if [ -n "$RESULT_UNCONFINED" ]; then
             ok "No profiles are unconfined"
@@ -61,8 +61,8 @@ apply() {
         fi
     done
 
-    RESULT_UNCONFINED=$(apparmor_status | grep "^0 processes are unconfined but have a profile defined")
-    RESULT_COMPLAIN=$(apparmor_status | grep "^0 profiles are in complain mode.")
+    RESULT_UNCONFINED=$(apparmor_status | grep "^0 processes are unconfined but have a profile defined" || true)
+    RESULT_COMPLAIN=$(apparmor_status | grep "^0 profiles are in complain mode." || true)
 
     if [ -n "$RESULT_UNCONFINED" ]; then
         ok "No profiles are unconfined"


### PR DESCRIPTION
1.7.1.4 look for unconfined processes with profile defined and profiles in complain mode with the following lines:

```
        RESULT_UNCONFINED=$($SUDO_CMD apparmor_status | grep "^0 processes are unconfined but have a profile defined"  
        RESULT_COMPLAIN=$($SUDO_CMD apparmor_status | grep "^0 profiles are in complain mode.")
```

However `grep` exits with return code 1 when no line is found and `set -e` at the beginning of script make it exit failing without log.

This PR corrects this behaviour by ensuring return value for each of these lines are 0 (variable remains empty)