### PR TITLE
missing shadowtools backup files is ok

### DIFF
--- a/bin/hardening/6.1.3_etc_gshadow-_permissions.sh
+++ b/bin/hardening/6.1.3_etc_gshadow-_permissions.sh
@@ -25,35 +25,45 @@ GROUPSOK='root shadow'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        crit "$FILE permissions were not set to $PERMISSIONS"
-    fi
-    has_file_one_of_ownership "$FILE" "$USER" "$GROUPSOK"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        crit "$FILE ownership was not set to $USER:$GROUPSOK"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            crit "$FILE permissions were not set to $PERMISSIONS"
+        fi
+        has_file_one_of_ownership "$FILE" "$USER" "$GROUPSOK"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            crit "$FILE ownership was not set to $USER:$GROUPSOK"
+        fi
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        info "fixing $FILE permissions to $PERMISSIONS"
-        chmod 0"$PERMISSIONS" "$FILE"
-    fi
-    has_file_one_of_ownership "$FILE" "$USER" "$GROUPSOK"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        info "fixing $FILE ownership to $USER:$GROUP"
-        chown "$USER":"$GROUP" "$FILE"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            info "fixing $FILE permissions to $PERMISSIONS"
+            chmod 0"$PERMISSIONS" "$FILE"
+        fi
+        has_file_one_of_ownership "$FILE" "$USER" "$GROUPSOK"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            info "fixing $FILE ownership to $USER:$GROUP"
+            chown "$USER":"$GROUP" "$FILE"
+        fi
     fi
 }
 

--- a/bin/hardening/6.1.6_etc_passwd-_permissions.sh
+++ b/bin/hardening/6.1.6_etc_passwd-_permissions.sh
@@ -24,35 +24,45 @@ GROUP='root'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        crit "$FILE permissions were not set to $PERMISSIONS"
-    fi
-    has_file_correct_ownership "$FILE" "$USER" "$GROUP"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        crit "$FILE ownership was not set to $USER:$GROUP"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            crit "$FILE permissions were not set to $PERMISSIONS"
+        fi
+        has_file_correct_ownership "$FILE" "$USER" "$GROUP"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            crit "$FILE ownership was not set to $USER:$GROUP"
+        fi
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        info "fixing $FILE permissions to $PERMISSIONS"
-        chmod 0"$PERMISSIONS" "$FILE"
-    fi
-    has_file_correct_ownership "$FILE" "$USER" "$GROUP"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        info "fixing $FILE ownership to $USER:$GROUP"
-        chown "$USER":"$GROUP" "$FILE"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            info "fixing $FILE permissions to $PERMISSIONS"
+            chmod 0"$PERMISSIONS" "$FILE"
+        fi
+        has_file_correct_ownership "$FILE" "$USER" "$GROUP"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            info "fixing $FILE ownership to $USER:$GROUP"
+            chown "$USER":"$GROUP" "$FILE"
+        fi
     fi
 }
 

--- a/bin/hardening/6.1.7_etc_shadow-_permissions.sh
+++ b/bin/hardening/6.1.7_etc_shadow-_permissions.sh
@@ -24,35 +24,45 @@ GROUP='shadow'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        crit "$FILE permissions were not set to $PERMISSIONS"
-    fi
-    has_file_correct_ownership "$FILE" "$USER" "$GROUP"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        crit "$FILE ownership was not set to $USER:$GROUP"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            crit "$FILE permissions were not set to $PERMISSIONS"
+        fi
+        has_file_correct_ownership "$FILE" "$USER" "$GROUP"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            crit "$FILE ownership was not set to $USER:$GROUP"
+        fi
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        info "fixing $FILE permissions to $PERMISSIONS"
-        chmod 0"$PERMISSIONS" "$FILE"
-    fi
-    has_file_correct_ownership "$FILE" "$USER" "$GROUP"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        info "fixing $FILE ownership to $USER:$GROUP"
-        chown "$USER":"$GROUP" "$FILE"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            info "fixing $FILE permissions to $PERMISSIONS"
+            chmod 0"$PERMISSIONS" "$FILE"
+        fi
+        has_file_correct_ownership "$FILE" "$USER" "$GROUP"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            info "fixing $FILE ownership to $USER:$GROUP"
+            chown "$USER":"$GROUP" "$FILE"
+        fi
     fi
 }
 

--- a/bin/hardening/6.1.8_etc_group-_permissions.sh
+++ b/bin/hardening/6.1.8_etc_group-_permissions.sh
@@ -24,35 +24,45 @@ GROUP='root'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        crit "$FILE permissions were not set to $PERMISSIONS"
-    fi
-    has_file_correct_ownership "$FILE" "$USER" "$GROUP"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        crit "$FILE ownership was not set to $USER:$GROUP"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            crit "$FILE permissions were not set to $PERMISSIONS"
+        fi
+        has_file_correct_ownership "$FILE" "$USER" "$GROUP"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            crit "$FILE ownership was not set to $USER:$GROUP"
+        fi
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    has_file_correct_permissions "$FILE" "$PERMISSIONS"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct permissions"
+    does_file_exist "$FILE"
+    if [ "$FNRET" != 0 ]; then
+        ok "$FILE does not exist"
     else
-        info "fixing $FILE permissions to $PERMISSIONS"
-        chmod 0"$PERMISSIONS" "$FILE"
-    fi
-    has_file_correct_ownership "$FILE" "$USER" "$GROUP"
-    if [ "$FNRET" = 0 ]; then
-        ok "$FILE has correct ownership"
-    else
-        info "fixing $FILE ownership to $USER:$GROUP"
-        chown "$USER":"$GROUP" "$FILE"
+        has_file_correct_permissions "$FILE" "$PERMISSIONS"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct permissions"
+        else
+            info "fixing $FILE permissions to $PERMISSIONS"
+            chmod 0"$PERMISSIONS" "$FILE"
+        fi
+        has_file_correct_ownership "$FILE" "$USER" "$GROUP"
+        if [ "$FNRET" = 0 ]; then
+            ok "$FILE has correct ownership"
+        else
+            info "fixing $FILE ownership to $USER:$GROUP"
+            chown "$USER":"$GROUP" "$FILE"
+        fi
     fi
 }
 

--- a/tests/hardening/6.1.3_etc_gshadow-_permissions.sh
+++ b/tests/hardening/6.1.3_etc_gshadow-_permissions.sh
@@ -37,6 +37,12 @@ test_audit() {
     register_test contain "has correct ownership"
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    describe Missing File should be OK as well
+    rm "$test_file"
+    register_test retvalshouldbe 0
+    register_test contain "does not exist"
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     userdel "$test_user"
 }

--- a/tests/hardening/6.1.6_etc_passwd-_permissions.sh
+++ b/tests/hardening/6.1.6_etc_passwd-_permissions.sh
@@ -37,6 +37,12 @@ test_audit() {
     register_test contain "has correct ownership"
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    describe Missing File should be OK as well
+    rm "$test_file"
+    register_test retvalshouldbe 0
+    register_test contain "does not exist"
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     userdel "$test_user"
 }

--- a/tests/hardening/6.1.7_etc_shadow-_permissions.sh
+++ b/tests/hardening/6.1.7_etc_shadow-_permissions.sh
@@ -37,6 +37,12 @@ test_audit() {
     register_test contain "has correct ownership"
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    describe Missing File should be OK as well
+    rm "$test_file"
+    register_test retvalshouldbe 0
+    register_test contain "does not exist"
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     userdel "$test_user"
 }

--- a/tests/hardening/6.1.8_etc_group-_permissions.sh
+++ b/tests/hardening/6.1.8_etc_group-_permissions.sh
@@ -37,6 +37,12 @@ test_audit() {
     register_test contain "has correct ownership"
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    describe Missing File should be OK as well
+    rm "$test_file"
+    register_test retvalshouldbe 0
+    register_test contain "does not exist"
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     userdel "$test_user"
 }


### PR DESCRIPTION
For Section 6.1.* it should be ok if the shadowtools backup files (shadow-, passwd-, ...) are missing.

I wrapped the checks in a `does_file_exist` check. 