### PR TITLE
Fix empty fstab test

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -415,9 +415,9 @@ is_kernel_option_enabled() {
 is_a_partition() {
     local PARTITION=$1
     FNRET=128
-    if [ ! -f /etc/fstab ] || [ -n "$(sed '/^#/d' /etc/fstab)" ]; then
+    if [ ! -f /etc/fstab ] || [ -z "$(sed '/^#/d' /etc/fstab)" ]; then
         debug "/etc/fstab not found or empty, searching mountpoint"
-        if mountpoint "$PARTITION" | grep -qE ".*is a mountpoint.*"; then
+        if mountpoint -q "$PARTITION"; then
             FNRET=0
         fi
     else
@@ -448,8 +448,8 @@ is_mounted() {
 has_mount_option() {
     local PARTITION=$1
     local OPTION=$2
-    if [ ! -f /etc/fstab ] || [ -n "$(sed '/^#/d' /etc/fstab)" ]; then
-        debug "/etc/fstab not found or empty, readin current mount options"
+    if [ ! -f /etc/fstab ] || [ -z "$(sed '/^#/d' /etc/fstab)" ]; then
+        debug "/etc/fstab not found or empty, reading current mount options"
         has_mounted_option "$PARTITION" "$OPTION"
     else
         if grep "[[:space:]]${PARTITION}[[:space:]]" /etc/fstab | grep -vE "^#" | awk '{print $4}' | grep -q "bind"; then

--- a/tests/hardening/1.1.15_run_shm_nodev.sh
+++ b/tests/hardening/1.1.15_run_shm_nodev.sh
@@ -2,15 +2,14 @@
 # run-shellcheck
 test_audit() {
     describe Running on blank host
-    register_test retvalshouldbe 1
-    dismiss_count_for_test
+    register_test retvalshouldbe 0
     # shellcheck disable=2154
     run blank /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
     ln -s /dev/shm /run/shm
 
     describe Partition symlink
-    register_test retvalshouldbe 1
+    register_test retvalshouldbe 0
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
     # Cleanup

--- a/tests/hardening/1.1.16_run_shm_nosuid.sh
+++ b/tests/hardening/1.1.16_run_shm_nosuid.sh
@@ -3,14 +3,13 @@
 test_audit() {
     describe Running on blank host
     register_test retvalshouldbe 0
-    dismiss_count_for_test
     # shellcheck disable=2154
     run blank /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
     ln -s /dev/shm /run/shm
 
     describe Partition symlink
-    register_test retvalshouldbe 1
+    register_test retvalshouldbe 0
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
     # Cleanup

--- a/tests/hardening/1.1.17_run_shm_noexec.sh
+++ b/tests/hardening/1.1.17_run_shm_noexec.sh
@@ -3,14 +3,13 @@
 test_audit() {
     describe Running on blank host
     register_test retvalshouldbe 0
-    dismiss_count_for_test
     # shellcheck disable=2154
     run blank /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
     ln -s /dev/shm /run/shm
 
     describe Partition symlink
-    register_test retvalshouldbe 1
+    register_test retvalshouldbe 0
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
     # Cleanup


### PR DESCRIPTION
The test was checking if fstab is **not** empty, so we were always falling back on /proc/mounts
Before
```
hardening                 [INFO] Treating /opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh
hardening                 [DBG ] /opt/cis-hardening/bin/hardening//opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh --audit --sudo 
1.1.14_home_nodev         [DBG ] Audit argument detected, setting status to audit
1.1.14_home_nodev         [DBG ] Unknown option passed
1.1.14_home_nodev         [INFO] Working on 1.1.14_home_nodev
1.1.14_home_nodev         [INFO] [DESCRIPTION] /home partition with nodev option.
1.1.14_home_nodev         [DBG ] Audit argument detected, setting status to audit
1.1.14_home_nodev         [INFO] Checking Configuration
1.1.14_home_nodev         [INFO] Performing audit
1.1.14_home_nodev         [INFO] Verifying that /home is a partition
1.1.14_home_nodev         [DBG ] /etc/fstab not found or empty, searching mountpoint
1.1.14_home_nodev         [ OK ] /home is a partition
1.1.14_home_nodev         [DBG ] /etc/fstab not found or empty, readin current mount options
1.1.14_home_nodev         [DBG ] nodev has been detected in /proc/mounts for partition /home
1.1.14_home_nodev         [ OK ] /home has nodev in fstab
1.1.14_home_nodev         [DBG ] nodev has been detected in /proc/mounts for partition /home
1.1.14_home_nodev         [ OK ] /home mounted with nodev
1.1.14_home_nodev         [ OK ] Check Passed
hardening                 [DBG ] Script /opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh finished with exit code 0
hardening                 [DBG ] /opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh passed

```
After
```
hardening                 [INFO] Treating /opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh
hardening                 [DBG ] /opt/cis-hardening/bin/hardening//opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh --audit --sudo 
1.1.14_home_nodev         [DBG ] Audit argument detected, setting status to audit
1.1.14_home_nodev         [DBG ] Unknown option passed
1.1.14_home_nodev         [INFO] Working on 1.1.14_home_nodev
1.1.14_home_nodev         [INFO] [DESCRIPTION] /home partition with nodev option.
1.1.14_home_nodev         [DBG ] Audit argument detected, setting status to audit
1.1.14_home_nodev         [INFO] Checking Configuration
1.1.14_home_nodev         [INFO] Performing audit
1.1.14_home_nodev         [INFO] Verifying that /home is a partition
1.1.14_home_nodev         [DBG ] /home found in fstab
1.1.14_home_nodev         [ OK ] /home is a partition
1.1.14_home_nodev         [DBG ] nodev has been detected in fstab for partition /home
1.1.14_home_nodev         [ OK ] /home has nodev in fstab
1.1.14_home_nodev         [DBG ] nodev has been detected in /proc/mounts for partition /home
1.1.14_home_nodev         [ OK ] /home mounted with nodev
1.1.14_home_nodev         [ OK ] Check Passed
hardening                 [DBG ] Script /opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh finished with exit code 0
hardening                 [DBG ] /opt/cis-hardening/bin/hardening/1.1.14_home_nodev.sh passed
```