### PR TITLE
fix: Catch unexpected failures

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -103,6 +103,20 @@ debug() {
     if [ "$MACHINE_LOG_LEVEL" -ge 5 ]; then _logger "$GRAY" "[DBG ] $*"; fi
 }
 
+exception() {
+    # Trap exit code is the same as the trapped one unless we call an explicit exit
+    TRAP_CODE=$?
+    if [ "$ACTIONS_DONE" -ne 1 ]; then
+        if [ "$BATCH_MODE" -eq 1 ]; then
+            BATCH_OUTPUT="KO $SCRIPT_NAME $BATCH_OUTPUT KO{Unexpected exit code: $TRAP_CODE}"
+            becho "$BATCH_OUTPUT"
+        else
+            crit "Check failed with unexpected exit code: $TRAP_CODE"
+        fi
+        exit 1 # Means critical status
+    fi
+}
+
 #
 # sudo wrapper
 # issue crit state if not allowed to perform sudo

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -11,6 +11,7 @@ status=""
 forcedstatus=""
 SUDO_CMD=""
 SAVED_LOGLEVEL=""
+ACTIONS_DONE=0
 
 if [ -n "${LOGLEVEL:-}" ]; then
     SAVED_LOGLEVEL=$LOGLEVEL
@@ -111,6 +112,9 @@ if [ -z "$status" ]; then
     exit 2
 fi
 
+# We want to trap unexpected failures in check scripts
+trap exception EXIT
+
 case $status in
 enabled | true)
     info "Checking Configuration"
@@ -128,12 +132,15 @@ audit)
     ;;
 disabled | false)
     info "$SCRIPT_NAME is disabled, ignoring"
+    ACTIONS_DONE=1
     exit 2 # Means unknown status
     ;;
 *)
     warn "Wrong value for status : $status. Must be [ enabled | true | audit | disabled | false ]"
     ;;
 esac
+
+ACTIONS_DONE=1
 
 if [ "$CRITICAL_ERRORS_NUMBER" -eq 0 ]; then
     if [ "$BATCH_MODE" -eq 1 ]; then


### PR DESCRIPTION
We made the choice to exit on error (`set -e`) in hardening scripts, and those same scripts are sourcing `lib/main.sh` which calls audit/apply functions and print the check result.

So in the case of non-zero exit status in audit/apply functions, we immediately exit without printing further information, in particular when we're running batch mode.

To reproduce, we can simulate a "failure" in any hardening script, and check the output, for example : 
- Calling the hardening script directly, we don't have any feedback except the return code about a failure
```
# /opt/cis-hardening/bin/hardening/6.1.10_find_world_writable_file.sh
6.1.10_find_world_writabl [INFO] Working on 6.1.10_find_world_writable_file
6.1.10_find_world_writabl [INFO] [DESCRIPTION] Ensure no world writable files exist
6.1.10_find_world_writabl [INFO] Checking Configuration
6.1.10_find_world_writabl [INFO] Performing audit
6.1.10_find_world_writabl [INFO] Checking if there are world writable files
# echo $?
3
```
- Running the check using the wrapper, as it checks the exit code we can notice that it's not counted as passed, but except the summary we don't have any feedback (notice that because the script fails with an exit code != 1 , it's not counted as failed neither)
```
# /opt/cis-hardening/bin/hardening.sh --sudo --audit --only 6.1.10
hardening                 [INFO] Treating /opt/cis-hardening/bin/hardening/6.1.10_find_world_writable_file.sh
6.1.10_find_world_writabl [INFO] Working on 6.1.10_find_world_writable_file
6.1.10_find_world_writabl [INFO] [DESCRIPTION] Ensure no world writable files exist
6.1.10_find_world_writabl [INFO] Checking Configuration
6.1.10_find_world_writabl [INFO] Performing audit
6.1.10_find_world_writabl [INFO] Checking if there are world writable files
################### SUMMARY ###################
      Total Available Checks : 1
         Total Runned Checks : 1
         Total Passed Checks : [     0/1 ]
         Total Failed Checks : [     0/1 ]
   Enabled Checks Percentage : 100.00 %
       Conformity Percentage : 0 %
```
- The most important one, when using batch mode, we can't know which test failed (here we have 157/163 passing tests, but we only see 5 failing tests)
```
# /opt/cis-hardening/bin/hardening.sh --sudo --audit --batch | egrep '(KO|SUMMARY)'
KO 3.3.2_disable_icmp_redirect  KO{net.ipv4.conf.all.accept_redirects was not set to 0} OK{net.ipv4.conf.default.accept_redirects correctly set to 0} 
KO 4.2.1.1_install_syslog-ng  KO{syslog-ng is not installed!} 
KO 4.2.1.2_enable_syslog-ng  KO{syslog-ng is not installed!} 
KO 4.2.1.4_syslog_ng_logfiles_perm  KO{syslog-ng is not installed!} 
KO 4.2.1.5_syslog-ng_remote_host  KO{syslog-ng is not installed!} 
AUDIT_SUMMARY PASSED_CHECKS:157 RUN_CHECKS:163 TOTAL_CHECKS_AVAIL:233 CONFORMITY_PERCENTAGE:96.31
```
This PR tries to catch the unexpected failures in checks and report them by configuring an EXIT trap before calling audit/apply functions, and in case the exit is triggered before the configured actions are done, we print a critical error message (we also preserve the previous batch output in case the failure occurs in a script with multiple checks).

The previous commands give now the following output
- Calling the hardening script directly, we now have a log entry showing the failure, notice that the final exit code is now correctly set to 1 despite the error is triggered by an `exit 3`
```
# /opt/cis-hardening/bin/hardening/6.1.10_find_world_writable_file.sh
6.1.10_find_world_writabl [INFO] Working on 6.1.10_find_world_writable_file
6.1.10_find_world_writabl [INFO] [DESCRIPTION] Ensure no world writable files exist
6.1.10_find_world_writabl [INFO] Checking Configuration
6.1.10_find_world_writabl [INFO] Performing audit
6.1.10_find_world_writabl [INFO] Checking if there are world writable files
6.1.10_find_world_writabl [ KO ] Check failed with unexpected exit code: 3
# echo $?
1
```
- Running the check using the wrapper, we now have have the failure correctly counted
```
# /opt/cis-hardening/bin/hardening.sh --sudo --audit --only 6.1.10
hardening                 [INFO] Treating /opt/cis-hardening/bin/hardening/6.1.10_find_world_writable_file.sh
6.1.10_find_world_writabl [INFO] Working on 6.1.10_find_world_writable_file
6.1.10_find_world_writabl [INFO] [DESCRIPTION] Ensure no world writable files exist
6.1.10_find_world_writabl [INFO] Checking Configuration
6.1.10_find_world_writabl [INFO] Performing audit
6.1.10_find_world_writabl [INFO] Checking if there are world writable files
6.1.10_find_world_writabl [ KO ] Check failed with unexpected exit code: 3
################### SUMMARY ###################
      Total Available Checks : 1
         Total Runned Checks : 1
         Total Passed Checks : [     0/1 ]
         Total Failed Checks : [     1/1 ]
   Enabled Checks Percentage : 100.00 %
       Conformity Percentage : 0 %
```
- Now using batch mode, we see all failures
```
# /opt/cis-hardening/bin/hardening.sh --sudo --audit --batch | egrep '(KO|SUMMARY)'
KO 3.3.2_disable_icmp_redirect  KO{net.ipv4.conf.all.accept_redirects was not set to 0} OK{net.ipv4.conf.default.accept_redirects correctly set to 0} 
KO 4.2.1.1_install_syslog-ng  KO{syslog-ng is not installed!} 
KO 4.2.1.2_enable_syslog-ng  KO{syslog-ng is not installed!} 
KO 4.2.1.4_syslog_ng_logfiles_perm  KO{syslog-ng is not installed!} 
KO 4.2.1.5_syslog-ng_remote_host  KO{syslog-ng is not installed!} 
KO 6.1.10_find_world_writable_file  KO{Unexpected exit code: 3} 
AUDIT_SUMMARY PASSED_CHECKS:157 RUN_CHECKS:163 TOTAL_CHECKS_AVAIL:233 CONFORMITY_PERCENTAGE:96.31
```

Signed-off-by: Tarik Megzari <tarik.megzari@corp.ovh.com>