### PR TITLE
fix: Avoid find failures on too many files

### DIFF
--- a/bin/hardening/1.1.21_sticky_bit_world_writable_folder.sh
+++ b/bin/hardening/1.1.21_sticky_bit_world_writable_folder.sh
@@ -25,10 +25,10 @@ audit() {
     FS_NAMES=$(df --local -P | awk '{if (NR!=1) print $6}')
     if [ -n "$EXCEPTIONS" ]; then
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -regextype 'egrep' ! -regex $EXCEPTIONS -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type d \( -perm -0002 -a ! -perm -1000 \) -regextype 'egrep' ! -regex $EXCEPTIONS -print 2>/dev/null)
     else
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type d \( -perm -0002 -a ! -perm -1000 \) -print 2>/dev/null)
     fi
 
     if [ -n "$RESULT" ]; then
@@ -45,14 +45,14 @@ audit() {
 apply() {
     if [ -n "$EXCEPTIONS" ]; then
         # shellcheck disable=SC2086
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -regextype 'egrep' ! -regex $EXCEPTIONS -print 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -type d \( -perm -0002 -a ! -perm -1000 \) -regextype 'egrep' ! -regex $EXCEPTIONS -print 2>/dev/null)
     else
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -print 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -type d \( -perm -0002 -a ! -perm -1000 \) -print 2>/dev/null)
     fi
 
     if [ -n "$RESULT" ]; then
         warn "Setting sticky bit on world writable directories"
-        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d -perm -0002 2>/dev/null | xargs chmod a+t
+        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -type d -perm -0002 2>/dev/null | xargs chmod a+t
     else
         ok "All world writable directories have a sticky bit, nothing to apply"
     fi

--- a/bin/hardening/4.1.11_record_privileged_commands.sh
+++ b/bin/hardening/4.1.11_record_privileged_commands.sh
@@ -19,7 +19,7 @@ DESCRIPTION="Collect use of privileged commands."
 
 SUDO_CMD='sudo -n'
 # Find all files with setuid or setgid set
-AUDIT_PARAMS=$($SUDO_CMD find / -xdev \( -perm -4000 -o -perm -2000 \) -type f |
+AUDIT_PARAMS=$($SUDO_CMD find / -xdev -ignore_readdir_race \( -perm -4000 -o -perm -2000 \) -type f |
     awk '{print "-a always,exit -F path=" $1 " -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" }')
 FILE='/etc/audit/audit.rules'
 

--- a/bin/hardening/6.1.10_find_world_writable_file.sh
+++ b/bin/hardening/6.1.10_find_world_writable_file.sh
@@ -26,10 +26,10 @@ audit() {
 
     if [ -n "$EXCLUDED" ]; then
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -type f -perm -0002 -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type f -perm -0002 -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
     else
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -type f -perm -0002 -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type f -perm -0002 -print 2>/dev/null)
     fi
 
     if [ -n "$RESULT" ]; then
@@ -46,14 +46,14 @@ audit() {
 apply() {
     if [ -n "$EXCLUDED" ]; then
         # shellcheck disable=SC2086
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f -perm -0002 -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -type f -perm -0002 -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
     else
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f -perm -0002 -print 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -type f -perm -0002 -print 2>/dev/null)
     fi
 
     if [ -n "$RESULT" ]; then
         warn "chmoding o-w all files in the system"
-        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f -perm -0002 -print 2>/dev/null | xargs chmod o-w
+        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -type f -perm -0002 -print 2>/dev/null | xargs chmod o-w
     else
         ok "No world writable files found, nothing to apply"
     fi

--- a/bin/hardening/6.1.11_find_unowned_files.sh
+++ b/bin/hardening/6.1.11_find_unowned_files.sh
@@ -26,10 +26,10 @@ audit() {
     FS_NAMES=$(df --local -P | awk '{if (NR!=1) print $6}')
     if [ -n "$EXCLUDED" ]; then
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -nouser -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -nouser -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
     else
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -nouser -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -nouser -print 2>/dev/null)
     fi
     if [ -n "$RESULT" ]; then
         crit "Some unowned files are present"
@@ -45,13 +45,13 @@ audit() {
 apply() {
     if [ -n "$EXCLUDED" ]; then
         # shellcheck disable=SC2086
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nouser -regextype 'egrep' ! -regex $EXCLUDED -ls 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -regextype 'egrep' ! -regex $EXCLUDED -ls 2>/dev/null)
     else
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nouser -ls 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -ls 2>/dev/null)
     fi
     if [ -n "$RESULT" ]; then
         warn "Applying chown on all unowned files in the system"
-        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nouser -print 2>/dev/null | xargs chown "$USER"
+        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -print 2>/dev/null | xargs chown "$USER"
     else
         ok "No unowned files found, nothing to apply"
     fi

--- a/bin/hardening/6.1.12_find_ungrouped_files.sh
+++ b/bin/hardening/6.1.12_find_ungrouped_files.sh
@@ -26,10 +26,10 @@ audit() {
     FS_NAMES=$(df --local -P | awk '{if (NR!=1) print $6}')
     if [ -n "$EXCLUDED" ]; then
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -nogroup -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -nogroup -regextype 'egrep' ! -regex $EXCLUDED -print 2>/dev/null)
     else
         # shellcheck disable=SC2086
-        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -nogroup -print 2>/dev/null)
+        RESULT=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -nogroup -print 2>/dev/null)
     fi
     if [ -n "$RESULT" ]; then
         crit "Some ungrouped files are present"
@@ -45,13 +45,13 @@ audit() {
 apply() {
     if [ -n "$EXCLUDED" ]; then
         # shellcheck disable=SC2086
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nogroup -regextype 'egrep' ! -regex $EXCLUDED -ls 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nogroup -regextype 'egrep' ! -regex $EXCLUDED -ls 2>/dev/null)
     else
-        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nogroup -ls 2>/dev/null)
+        RESULT=$(df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nogroup -ls 2>/dev/null)
     fi
     if [ -n "$RESULT" ]; then
         warn "Applying chgrp on all ungrouped files in the system"
-        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nogroup -print 2>/dev/null | xargs chgrp "$GROUP"
+        df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nogroup -print 2>/dev/null | xargs chgrp "$GROUP"
     else
         ok "No ungrouped files found, nothing to apply"
     fi

--- a/bin/hardening/6.1.13_find_suid_files.sh
+++ b/bin/hardening/6.1.13_find_suid_files.sh
@@ -24,9 +24,9 @@ audit() {
     FS_NAMES=$(df --local -P | awk '{ if (NR!=1) print $6 }')
     # shellcheck disable=2086
     if [ -n "$IGNORED_PATH" ]; then
-        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -type f -perm -4000 -regextype 'egrep' ! -regex $IGNORED_PATH -print)
+        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type f -perm -4000 -regextype 'egrep' ! -regex $IGNORED_PATH -print)
     else
-        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -type f -perm -4000 -print)
+        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type f -perm -4000 -print)
     fi
     BAD_BINARIES=""
     for BINARY in $FOUND_BINARIES; do

--- a/bin/hardening/6.1.14_find_sgid_files.sh
+++ b/bin/hardening/6.1.14_find_sgid_files.sh
@@ -24,9 +24,9 @@ audit() {
     FS_NAMES=$(df --local -P | awk '{ if (NR!=1) print $6 }')
     # shellcheck disable=2086
     if [ -n "$IGNORED_PATH" ]; then
-        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -type f -perm -2000 -regextype 'egrep' ! -regex $IGNORED_PATH -print)
+        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type f -perm -2000 -regextype 'egrep' ! -regex $IGNORED_PATH -print)
     else
-        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -type f -perm -2000 -print)
+        FOUND_BINARIES=$($SUDO_CMD find $FS_NAMES -xdev -ignore_readdir_race -type f -perm -2000 -print)
     fi
     BAD_BINARIES=""
     for BINARY in $FOUND_BINARIES; do


### PR DESCRIPTION
On filesystems with too many ephemeral files, some files may disappear between the time the find command builds the files list and the time it stats them. By default, find will fail when this happens. If we pass `-ignore_readdir_race` parameter, it will simply ignore those files

In our case, as we always check for files with wrong permissions, if they are removed meanwhile, it's not an issue at all.

Signed-off-by: Tarik Megzari <tarik.megzari@corp.ovh.com>