### PR TITLE
fix: add 10s wait timeout on iptables command

### DIFF
--- a/bin/hardening/3.5.4.1.1_net_fw_default_policy_drop.sh
+++ b/bin/hardening/3.5.4.1.1_net_fw_default_policy_drop.sh
@@ -21,6 +21,7 @@ PACKAGE="iptables"
 FW_CHAINS="INPUT FORWARD"
 FW_POLICY="DROP"
 FW_CMD="iptables"
+FW_TIMEOUT="10"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
@@ -28,7 +29,7 @@ audit() {
     if [ "$FNRET" != 0 ]; then
         crit "$PACKAGE is not installed!"
     else
-        ipt=$($SUDO_CMD "$FW_CMD" -nL 2>/dev/null || true)
+        ipt=$($SUDO_CMD "$FW_CMD" -w "$FW_TIMEOUT" -nL 2>/dev/null || true)
         if [[ -z "$ipt" ]]; then
             crit "Empty return from $FW_CMD command. Aborting..."
             return


### PR DESCRIPTION
When the tested server has its iptables heavily manipulated (e.g Kubernetes)
The lock aquirement can sometimes fail, hence generating false positives
The command will retry 10 times with a 1 second interval