### PR TITLE
fix: ensure mountpoints are properly detected

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -424,6 +424,9 @@ is_a_partition() {
         if grep "[[:space:]]$1[[:space:]]" /etc/fstab | grep -vqE "^#"; then
             debug "$PARTITION found in fstab"
             FNRET=0
+        elif mountpoint -q "$PARTITION"; then
+            debug "$PARTITION found in /proc fs"
+            FNRET=0
         else
             debug "Unable to find $PARTITION in fstab"
             FNRET=1
@@ -461,6 +464,9 @@ has_mount_option() {
         if grep "[[:space:]]${PARTITION}[[:space:]]" /etc/fstab | grep -vE "^#" | awk '{print $4}' | grep -q "$OPTION"; then
             debug "$OPTION has been detected in fstab for partition $PARTITION"
             FNRET=0
+        elif mountpoint -q "$PARTITION"; then
+            debug "$OPTION not detected in fstab, but $PARTITION is a mount point searching in /proc fs"
+            has_mounted_option "$PARTITION" "$OPTION"
         else
             debug "Unable to find $OPTION in fstab for partition $PARTITION"
             FNRET=1

--- a/tests/hardening/1.1.15_run_shm_nodev.sh
+++ b/tests/hardening/1.1.15_run_shm_nodev.sh
@@ -12,8 +12,15 @@ test_audit() {
     register_test retvalshouldbe 0
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    echo "dummy entry" >>/etc/fstab
+
+    describe Fstab with a real entry to match runtime partitions
+    register_test retvalshouldbe 0
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     rm /run/shm
+    sed "/dummy entry/d" /etc/fstab
 
     ##################################################################
     # For this test, we only check that it runs properly on a blank  #

--- a/tests/hardening/1.1.16_run_shm_nosuid.sh
+++ b/tests/hardening/1.1.16_run_shm_nosuid.sh
@@ -12,8 +12,15 @@ test_audit() {
     register_test retvalshouldbe 0
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    echo "dummy entry" >>/etc/fstab
+
+    describe Fstab with a real entry to match runtime partitions
+    register_test retvalshouldbe 0
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     rm /run/shm
+    sed "/dummy entry/d" /etc/fstab
 
     ##################################################################
     # For this test, we only check that it runs properly on a blank  #

--- a/tests/hardening/1.1.17_run_shm_noexec.sh
+++ b/tests/hardening/1.1.17_run_shm_noexec.sh
@@ -12,8 +12,15 @@ test_audit() {
     register_test retvalshouldbe 0
     run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
 
+    echo "dummy entry" >>/etc/fstab
+
+    describe Fstab with a real entry to match runtime partitions
+    register_test retvalshouldbe 0
+    run resolved /opt/debian-cis/bin/hardening/"${script}".sh --audit-all
+
     # Cleanup
     rm /run/shm
+    sed "/dummy entry/d" /etc/fstab
 
     ##################################################################
     # For this test, we only check that it runs properly on a blank  #


### PR DESCRIPTION
Fixes #155
When real entries are present in fstab, system startup or runtime mountpoints are now properly detected Add a supplementary check in case of partition not present in fstab