### PR TITLE
fix: force xz compression during .deb build

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential devscripts debhelper
-          sudo debuild --buildinfo-option=-O -us -uc -b -j8
+          sudo debuild --buildinfo-option=-O -us -uc -b -j8 --compression=xz
           find ../ -name "*.deb" -exec mv {} cis-hardening.deb \;
       # DELETE THE TAG NAMED LATEST AND THE CORRESPONDING RELEASE
       - name: Delete the tag latest and the release latest

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential devscripts debhelper
-          sudo debuild --buildinfo-option=-O -us -uc -b -j8
+          sudo debuild --buildinfo-option=-O -us -uc -b -j8 --compression=xz
           find ../ -name "*.deb" -exec mv {} cis-hardening.deb \;
       # DELETE THE TAG NAMED LATEST AND THE CORRESPONDING RELEASE
       - name: Delete the tag latest and the release latest


### PR DESCRIPTION
zst compression is only available on Debian 12, since the release is built on Ubuntu latest, this was breaking release. 
Fixes #175