### PR TITLE
fix: 99.1.3_acc_sudoers_no_all: fix a race condition

### DIFF
--- a/bin/hardening/99.1.3_acc_sudoers_no_all.sh
+++ b/bin/hardening/99.1.3_acc_sudoers_no_all.sh
@@ -60,7 +60,13 @@ audit() {
     fi
     for file in $FILES; do
         if $SUDO_CMD [ ! -r "$file" ]; then
-            crit "$file is not readable"
+            debug "$file is not readable, but it might just have disappeared since we've listed the folder contents, re-check that it exists"
+            if $SUDO_CMD [ -e "$file" ]; then
+                crit "$file is not readable"
+            else
+                debug "$file has disappeared, ignore it"
+                continue
+            fi
         else
             if ! $SUDO_CMD grep -E "$REGEX" "$file" &>/dev/null; then
                 if [ $skiplog = 0 ]; then


### PR DESCRIPTION
On systems where /etc/sudoers.d might be updated often by some automated means, this check might raise a critical when a previously present file (during the ls) is no longer present (during its attempted read), so before raising a critical, re-check that it does exists first.