### PR TITLE
Add bind mount support

### DIFF
--- a/bin/hardening/1.1.10_var_tmp_noexec.sh
+++ b/bin/hardening/1.1.10_var_tmp_noexec.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.11.1_var_log_noexec.sh
+++ b/bin/hardening/1.1.11.1_var_log_noexec.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.11.2_var_log_nosuid.sh
+++ b/bin/hardening/1.1.11.2_var_log_nosuid.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.11.3_var_log_nodev.sh
+++ b/bin/hardening/1.1.11.3_var_log_nodev.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.12.1_var_log_audit_noexec.sh
+++ b/bin/hardening/1.1.12.1_var_log_audit_noexec.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.12.2_var_log_audit_nosuid.sh
+++ b/bin/hardening/1.1.12.2_var_log_audit_nosuid.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.12.3_var_log_audit_nodev.sh
+++ b/bin/hardening/1.1.12.3_var_log_audit_nodev.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.14.1_home_nosuid.sh
+++ b/bin/hardening/1.1.14.1_home_nosuid.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.14_home_nodev.sh
+++ b/bin/hardening/1.1.14_home_nodev.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.6.1_var_nodev.sh
+++ b/bin/hardening/1.1.6.1_var_nodev.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.6.2_var_nosuid.sh
+++ b/bin/hardening/1.1.6.2_var_nosuid.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.8_var_tmp_nodev.sh
+++ b/bin/hardening/1.1.8_var_tmp_nodev.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/bin/hardening/1.1.9_var_tmp_nosuid.sh
+++ b/bin/hardening/1.1.9_var_tmp_nosuid.sh
@@ -53,7 +53,14 @@ apply() {
     if [ "$FNRET" = 0 ]; then
         ok "$PARTITION is correctly set"
     elif [ "$FNRET" = 2 ]; then
-        crit "$PARTITION is not a partition, correct this by yourself, I cannot help you here"
+        info "Adding bind to fstab"
+        add_bind_option_to_fstab "$PARTITION"
+        info "Mounting $PARTITION"
+        mount_bind_partition "$PARTITION"
+        info "Adding $OPTION to fstab"
+        add_option_to_fstab "$PARTITION" "$OPTION"
+        info "Remounting $PARTITION from fstab"
+        remount_partition "$PARTITION"
     elif [ "$FNRET" = 1 ]; then
         info "Adding $OPTION to fstab"
         add_option_to_fstab "$PARTITION" "$OPTION"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -500,6 +500,28 @@ add_option_to_fstab() {
     sed -ie "s;\(.*\)\(\s*\)\s\($PARTITION\)\s\(\s*\)\(\w*\)\(\s*\)\(\w*\)*;\1\2 \3 \4\5\6\7,$OPTION;" /etc/fstab
 }
 
+add_bind_option_to_fstab() {
+    local PARTITION=$1
+    FNRET=0
+    is_a_partition "$PARTITION"
+    if [ $FNRET -gt 0 ]; then
+        if ! [ -d "$PARTITION" ]; then
+            debug "Creating directory $PARTITION"
+            mkdir -p "$PARTITION"
+        fi
+        debug "Adding bind option for $PARTITION in fstab"
+        backup_file "/etc/fstab"
+        debug "Adding this line to fstab: $PARTITION $PARTITION none bind 0 0"
+        echo "$PARTITION $PARTITION none bind 0 0" >> /etc/fstab
+    fi
+}
+
+mount_bind_partition() {
+    local PARTITION=$1
+    debug "Mounting $PARTITION with bind option"
+    mount -o bind -t none "$PARTITION" "$PARTITION"
+}
+
 remount_partition() {
     local PARTITION=$1
     debug "Remounting $PARTITION"


### PR DESCRIPTION
For the following directories:
    1. `/var/`
    2. `/var/log/`
    3. `/var/tmp/`
    4. `/var/log/audit/`
    5. `/home/`
  ensuring separate partition exists is level 2, while ensuring certain options
  are set is level1.

If you use level 1 profile, ensuring seperate partition exists is not required, but ensuring certain options are set is required.

This can be achieved by bind mount:

```
$ /var/log/audit/test.sh
I can be executed.
$ sudo mount -o bind,noexec /var/log/audit /var/log/audit
$ /var/log/audit/test.sh
-bash: /var/log/audit/test.sh: Permission denied
```

This commit adds bind mount to those directories, if they are not real partition.