### PR TITLE
Allow multiple exception users to be defined for 99.5.2.4_ssh_keys_from

### DIFF
--- a/bin/hardening/99.5.2.4_ssh_keys_from.sh
+++ b/bin/hardening/99.5.2.4_ssh_keys_from.sh
@@ -26,7 +26,7 @@ AUTHKEYFILE_PATTERN_DEFAULT=".ssh/authorized_keys .ssh/authorized_keys2"
 
 ALLOWED_IPS=""
 USERS_TO_CHECK=""
-EXCEPTION_USER=""
+EXCEPTION_USERS=""
 
 ALLOWED_NOLOGIN_SHELLS="/bin/false /usr/sbin/nologin"
 
@@ -137,7 +137,10 @@ audit() {
             continue
         else
             info "User $user has a valid shell ($shell)."
-            if [ "$user" = "root" ] && [ "$user" != "$EXCEPTION_USER" ]; then
+            if grep -qw "$user" <<<"$EXCEPTION_USERS"; then
+                info "User $user is named in EXEPTION_USERS and is thus skipped from check."
+                continue
+            elif [ "$user" = "root" ]; then
                 check_dir /root
                 continue
             elif $SUDO_CMD [ ! -d /home/"$user" ]; then
@@ -164,7 +167,7 @@ status=audit
 # Put authorized IPs you want to allow in "from" field of authorized_keys
 ALLOWED_IPS=""
 USERS_TO_CHECK=""
-EXCEPTION_USER=""
+EXCEPTION_USERS=""
 EOF
 }
 

--- a/tests/hardening/99.5.2.4_ssh_keys_from.sh
+++ b/tests/hardening/99.5.2.4_ssh_keys_from.sh
@@ -25,8 +25,6 @@ test_audit() {
     describe Check /root is used for root user instead of home by placing key without from field
     register_test retvalshouldbe 1
     run rootcheck "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
-    # clean up so we dont break the upcoming tests
-    rm -rf /root/.ssh
 
     echo 'EXCEPTION_USERS="root exceptiontestuser"' >>"${CIS_CONF_DIR}/conf.d/${script}.cfg"
     useradd -s /bin/bash exceptiontestuser
@@ -96,5 +94,5 @@ test_audit() {
     userdel exceptiontestuser
     userdel jeantestuser
     userdel -r jeantest2
-    rm -f /tmp/key1 /tmp/key1.pub /tmp/rootkey1.pub
+    rm -f /tmp/key1 /tmp/key1.pub /tmp/rootkey1.pub /root/.ssh
 }

--- a/tests/hardening/99.5.2.4_ssh_keys_from.sh
+++ b/tests/hardening/99.5.2.4_ssh_keys_from.sh
@@ -94,5 +94,6 @@ test_audit() {
     userdel exceptiontestuser
     userdel jeantestuser
     userdel -r jeantest2
-    rm -f /tmp/key1 /tmp/key1.pub /tmp/rootkey1.pub /root/.ssh
+    rm -f /tmp/key1 /tmp/key1.pub /tmp/rootkey1.pub
+    rm -rf /root/.ssh
 }


### PR DESCRIPTION
This PR allows excluding multiple users from the check in 99.5.2.4.

The root user already gets a special treatment by checking /root instead of /home/* which makes sense but this was never really tested since "root" was used as the exception user in the tests.

I added a test that checks that /root is actually used for checking the root users ssh auth keys and a test that checks the new feature of excluding multiple users.

Be aware that the config/env-key EXCEPTION_USER was renamed to EXCEPTION_USER**S**