### PR TITLE
fix: Allow --only option to be called multiple times

### DIFF
--- a/bin/hardening.sh
+++ b/bin/hardening.sh
@@ -299,7 +299,7 @@ for SCRIPT in $(find "${CIS_CHECKS_DIR}"/ -name "*.sh" | sort -V); do
         SCRIPT_PREFIX=$(grep -Eo '^[0-9.]+' <<<"$(basename "$SCRIPT")")
         # shellcheck disable=SC2001
         SCRIPT_PREFIX_RE=$(sed -e 's/\./\\./g' <<<"$SCRIPT_PREFIX")
-        if ! grep -qwE "(^| )$SCRIPT_PREFIX_RE" <<<"${TEST_LIST[@]}"; then
+        if ! grep -qE "(^|[[:space:]])$SCRIPT_PREFIX_RE([[:space:]]|$)" <<<"${TEST_LIST[@]}"; then
             # not in the list
             continue
         fi


### PR DESCRIPTION
--only option was affected with a grep bug since 2017. the regex was not able to parse more than the first passed argument.

fixes #224