### PR TITLE
fix: catch cidr network in ssh keys

### DIFF
--- a/bin/hardening/99.5.2.4_ssh_keys_from.sh
+++ b/bin/hardening/99.5.2.4_ssh_keys_from.sh
@@ -19,7 +19,7 @@ DESCRIPTION="Check <from> field in ssh authorized keys files for users with logi
 
 # Regex looking for empty, hash starting lines, or 'from="127.127.127,127.127.127" ssh'
 # shellcheck disable=2089
-REGEX_FROM_IP="from=(?:'|\")(,?(\d{1,3}(\.\d{1,3}){3}))+(?:'|\")"
+REGEX_FROM_IP="from=(?:'|\")(,?(\d{1,3}(\.\d{1,3}){3})(\/\d{1,2})?)+(?:'|\")"
 REGEX_OK_LINES="(^(#|$)|($REGEX_FROM_IP))"
 AUTHKEYFILE_PATTERN=""
 AUTHKEYFILE_PATTERN_DEFAULT=".ssh/authorized_keys .ssh/authorized_keys2"

--- a/tests/hardening/99.5.2.4_ssh_keys_from.sh
+++ b/tests/hardening/99.5.2.4_ssh_keys_from.sh
@@ -72,11 +72,11 @@ test_audit() {
     run allwdfromip "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
     # shellcheck disable=2016
-    echo 'ALLOWED_IPS="$ALLOWED_IPS 127.0.0.1,10.2.3.1"' >>"${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    echo 'ALLOWED_IPS="$ALLOWED_IPS 127.0.0.1,10.2.3.1/8"' >>"${CIS_CONF_DIR}/conf.d/${script}.cfg"
     {
         echo -n 'from="10.0.1.2",command="echo bla" '
         cat /tmp/key1.pub
-        echo -n 'command="echo bla,from="10.0.1.2,10.2.3.1"" '
+        echo -n 'command="echo bla,from="10.0.1.2,10.2.3.1/8"" '
         cat /tmp/key1.pub
     } >>/home/secaudit/.ssh/authorized_keys2
     describe Key with from and command options


### PR DESCRIPTION
To also catch in ssk keys:

- from="10.0.1.0/8"

- from="10.0.1.0/24,10.0.2.0/24"
