### PR TITLE
fix: invalid behavior on sid/alternative in 5.3.4/99.5.4.5.1

### DIFF
--- a/bin/hardening/5.3.4_acc_pam_sha512.sh
+++ b/bin/hardening/5.3.4_acc_pam_sha512.sh
@@ -49,7 +49,7 @@ apply() {
             ok "$CONF_LINE is present in $CONF_FILE"
         else
             warn "$CONF_LINE is not present in $CONF_FILE"
-            if [ "$DEB_MAJ_VER" -ge "11" ]; then
+            if [ "$DEB_MAJ_VER" = "sid" ] || [ "$DEB_MAJ_VER" -ge "11" ]; then
                 add_line_file_before_pattern "$CONF_FILE" "password [success=1 default=ignore] pam_unix.so yescrypt" "# pam-auth-update(8) for details."
             else
                 add_line_file_before_pattern "$CONF_FILE" "password [success=1 default=ignore] pam_unix.so sha512" "# pam-auth-update(8) for details."
@@ -67,12 +67,11 @@ check_config() {
 # We need to call this in the subs called by main.sh when it is sourced, otherwise it would
 # either be too soon (DEB_MAJ_VER not defined) or too late (test has already been run)
 _set_vars_jit() {
-    if [ "$DEB_MAJ_VER" -ge "11" ]; then
+    if [ "$DEB_MAJ_VER" = "sid" ] || [ "$DEB_MAJ_VER" -ge "11" ]; then
         CONF_LINE="^\s*password\s.+\s+pam_unix\.so\s+.*(sha512|yescrypt)" # https://github.com/ovh/debian-cis/issues/158
     else
         CONF_LINE="^\s*password\s.+\s+pam_unix\.so\s+.*sha512"
     fi
-    unset -f _set_vars_jit
 }
 
 # Source Root Dir Parameter

--- a/bin/hardening/99.5.4.5.1_acc_logindefs_sha512.sh
+++ b/bin/hardening/99.5.4.5.1_acc_logindefs_sha512.sh
@@ -48,7 +48,7 @@ apply() {
         if [ "$FNRET" != 0 ]; then
             add_end_of_file "$CONF_FILE" "$CONF_LINE"
         else
-            info "Parameter $SSH_PARAM is present but with the wrong value -- Fixing"
+            info "Parameter $CONF_LINE is present but with the wrong value -- Fixing"
             replace_in_file "$CONF_FILE" "^$(echo "$CONF_LINE" | cut -d ' ' -f1)[[:space:]]*.*" "$CONF_LINE"
         fi
     fi
@@ -63,14 +63,13 @@ check_config() {
 # We need to call this in the subs called by main.sh when it is sourced, otherwise it would
 # either be too soon (DEB_MAJ_VER not defined) or too late (test has already been run)
 _set_vars_jit() {
-    if [ "$DEB_MAJ_VER" -ge "11" ]; then
+    if [ "$DEB_MAJ_VER" = "sid" ] || [ "$DEB_MAJ_VER" -ge "11" ]; then
         CONF_LINE_REGEX="ENCRYPT_METHOD (SHA512|yescrypt|YESCRYPT)"
         CONF_LINE="ENCRYPT_METHOD YESCRYPT"
     else
         CONF_LINE_REGEX="ENCRYPT_METHOD SHA512"
         CONF_LINE="ENCRYPT_METHOD SHA512"
     fi
-    unset -f _set_vars_jit
 }
 
 # Source Root Dir Parameter

--- a/tests/hardening/5.3.4_acc_pam_sha512.sh
+++ b/tests/hardening/5.3.4_acc_pam_sha512.sh
@@ -6,4 +6,50 @@ test_audit() {
     register_test contain "is present in /etc/pam.d/common-password"
     # shellcheck disable=2154
     run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe Tests purposely failing
+    sed -i '/pam_unix.so/ s/sha512/sha256/' "/etc/pam.d/common-password"   # Debian 10
+    sed -i '/pam_unix.so/ s/yescrypt/sha256/' "/etc/pam.d/common-password" # Debian 11+
+    register_test retvalshouldbe 1
+    register_test contain "is not present"
+    run noncompliant "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe correcting situation
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe Checking resolved state
+    register_test retvalshouldbe 0
+    register_test contain "is present in /etc/pam.d/common-password"
+    run solvedsid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    # DEB_MAJ_VER cannot be overwritten here;
+    # therefore we need to trick get_debian_major_version
+    ORIGINAL_DEB_VER="$(cat /etc/debian_version)"
+    echo "sid" >/etc/debian_version
+
+    describe Running on blank host as sid
+    register_test retvalshouldbe 0
+    register_test contain "(sha512|yescrypt)"
+    run blanksid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe Tests purposely failing as sid
+    sed -i '/pam_unix.so/ s/sha512/sha256/' "/etc/pam.d/common-password"   # Debian 10
+    sed -i '/pam_unix.so/ s/yescrypt/sha256/' "/etc/pam.d/common-password" # Debian 11+
+    register_test retvalshouldbe 1
+    register_test contain "is not present"
+    run noncompliantsid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe correcting situation as sid
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe Checking resolved state as sid
+    register_test retvalshouldbe 0
+    register_test contain "is present in /etc/pam.d/common-password"
+    run solvedsid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    # Cleanup
+    echo -n "$ORIGINAL_DEB_VER" >/etc/debian_version
+    unset ORIGINAL_DEB_VER
 }

--- a/tests/hardening/99.5.4.5.1_acc_logindefs_sha512.sh
+++ b/tests/hardening/99.5.4.5.1_acc_logindefs_sha512.sh
@@ -28,11 +28,43 @@ test_audit() {
     run wrongconf "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
     describe Correcting situation
-    sed -i 's/disabled/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
     "${CIS_CHECKS_DIR}/${script}.sh" || true
 
     describe Checking resolved state
-    mv /tmp/login.defs.bak /etc/login.defs
     register_test retvalshouldbe 0
+    register_test contain "is present in /etc/login.defs"
     run sha512pass "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    # DEB_MAJ_VER cannot be overwritten here;
+    # therefore we need to trick get_debian_major_version
+    ORIGINAL_DEB_VER="$(cat /etc/debian_version)"
+    echo "sid" >/etc/debian_version
+
+    describe Running on blank host as sid
+    register_test retvalshouldbe 0
+    register_test contain "(SHA512|yescrypt|YESCRYPT)"
+    # shellcheck disable=2154
+    run blanksid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    cp /etc/login.defs /tmp/login.defs.bak
+    sed -ir 's/ENCRYPT_METHOD[[:space:]]\+.*/ENCRYPT_METHOD MD5/' /etc/login.defs
+
+    describe Fail: wrong hash function configuration as sid
+    register_test retvalshouldbe 1
+    register_test contain "(SHA512|yescrypt|YESCRYPT)"
+    run wrongconfsid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe Correcting situation as sid
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" || true
+
+    describe Checking resolved state as sid
+    register_test retvalshouldbe 0
+    register_test contain "(SHA512|yescrypt|YESCRYPT)"
+    run sha512passsid "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    # Cleanup
+    echo -n "$ORIGINAL_DEB_VER" >/etc/debian_version
+    unset ORIGINAL_DEB_VER
 }


### PR DESCRIPTION
On Debian Sid / alternative distributions (such as Ubuntu), these checks would fail with `sid: integer expression expected`, which is to be expected since `$DEB_MAJ_VER` is set to a string, not an integer.

This small PR fixes that in a similar fashion to other checks in the source tree.