### PR TITLE
fix: Update 1.1.23_disable_usb_storage.sh

### DIFF
--- a/bin/hardening/1.1.23_disable_usb_storage.sh
+++ b/bin/hardening/1.1.23_disable_usb_storage.sh
@@ -20,7 +20,7 @@ DESCRIPTION="Disable USB storage."
 # Note: we check /proc/config.gz to be compliant with both monolithic and modular kernels
 
 KERNEL_OPTION="CONFIG_USB_STORAGE"
-MODULE_NAME="usb-storage"
+MODULE_NAME="usb_storage"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {


### PR DESCRIPTION
Found a bug in 1.1.23 - Disable USB storage


USB kernel check was passed, even if usb_storage was loaded.



Source for usb-storage/usb_storage: 
- https://bytefreaks.net/tag/usb_storage
- https://unix.stackexchange.com/questions/144807/which-kernel-module-name-is-currently-correct-usb-storage-or-usb-storage


`lsmod | grep -E 'usb_storage|usb-storage'` output on my debian 11 installation:
```
...
usb_storage            81920  1 uas
...
```

when altering `1.1.23_disable_usb_storage.sh` to check for usb_storage instead of usb-storage, it works as expected on my systems

Solves issue #249 