### PR TITLE
fix: debian package does not include "versions"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -28,6 +28,7 @@ override_dh_install:
 	# (ls | sort -V | xargs -i echo /opt/cis-hardening/etc/conf.d/{} -- without README -- with ../hardening.cfg)
 	cp -R etc $(CURDIR)/debian/$(PACKAGE)/opt/$(PACKAGE)/
 	cp -R lib $(CURDIR)/debian/$(PACKAGE)/opt/$(PACKAGE)/
+	cp -R versions $(CURDIR)/debian/$(PACKAGE)/opt/$(PACKAGE)/
 	# cleanup git stuff if any
 	find $(CURDIR)/debian/$(PACKAGE) -type f -name .gitignore -delete
 


### PR DESCRIPTION
Related to #259: https://github.com/ovh/debian-cis/issues/259