### PR TITLE
fix: disable_usb_storage

### DIFF
--- a/bin/hardening/disable_usb_storage.sh
+++ b/bin/hardening/disable_usb_storage.sh
@@ -20,7 +20,7 @@ DESCRIPTION="Disable USB storage."
 # Note: we check /proc/config.gz to be compliant with both monolithic and modular kernels
 
 KERNEL_OPTION="CONFIG_USB_STORAGE"
-MODULE_NAME="usb-storage"
+MODULE_NAME="usb_storage"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {


### PR DESCRIPTION
issue #249 : usb storage module is spelled "usb-storage" instead of "usb_storage"