### PR TITLE
Update audit scripts for find log_file in file /etc/audit/auditd.conf

### DIFF
--- a/bin/hardening/audit_log_directory_perms.sh
+++ b/bin/hardening/audit_log_directory_perms.sh
@@ -27,7 +27,7 @@ audit() {
     does_file_exist "$AUDITD_CONF_FILE"
     if [ "$FNRET" -eq 0 ]; then
 
-        AUDIT_LOG_DIRECTORY="$(dirname "$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F"=" '{print $2}')")"
+        AUDIT_LOG_DIRECTORY="$(dirname "$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F '=' '{print $2}' | xargs)")"
         local log_dir_perms
         log_dir_perms=$(stat -Lc %a "$AUDIT_LOG_DIRECTORY")
 

--- a/bin/hardening/audit_log_group.sh
+++ b/bin/hardening/audit_log_group.sh
@@ -27,8 +27,8 @@ audit() {
     does_file_exist "$AUDITD_CONF_FILE"
     if [ "$FNRET" -eq 0 ]; then
         local log_file
-        log_file=$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F "=" '{print $2}')
-        log_group=$($SUDO_CMD grep -E "^\s*log_group" "$AUDITD_CONF_FILE" | awk -F "=" '{print $2}')
+        log_file=$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F '=' '{print $2}' | xargs)
+        log_group=$($SUDO_CMD grep -E "^\s*log_group" "$AUDITD_CONF_FILE" | awk -F '=' '{print $2}' | xargs)
         # look for all files in the directory
         AUDIT_INVALID_LOGS=$(find "$(dirname "$log_file")" -type f ! -group "$AUDIT_LOG_GROUP" -a ! -group root -exec stat -Lc "%n %G" {} +)
 

--- a/bin/hardening/audit_log_perms.sh
+++ b/bin/hardening/audit_log_perms.sh
@@ -25,7 +25,7 @@ audit() {
     does_file_exist "$AUDITD_CONF_FILE"
     if [ "$FNRET" -eq 0 ]; then
         local log_file
-        log_file=$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F "=" '{print $2}')
+        log_file=$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F '=' '{print $2}' | xargs)
         # look for all files in the directory
         AUDIT_INVALID_LOGS=$($SUDO_CMD find "$(dirname "$log_file")" -type f -perm /0137)
 

--- a/bin/hardening/audit_log_user.sh
+++ b/bin/hardening/audit_log_user.sh
@@ -27,7 +27,7 @@ audit() {
     does_file_exist "$AUDITD_CONF_FILE"
     if [ "$FNRET" -eq 0 ]; then
         local log_file
-        log_file=$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F "=" '{print $2}')
+        log_file=$($SUDO_CMD grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F '=' '{print $2}' | xargs)
         # look for all files in the directory
         AUDIT_INVALID_LOGS=$(find "$(dirname "$log_file")" -type f ! -user "$AUDIT_LOG_USER" -exec stat -Lc "%n %U" {} +)
 


### PR DESCRIPTION
**Summary**
This PR fixes incorrect handling of the log_file directive from /etc/audit/auditd.conf in the following hardening scripts:
* audit_log_directory_perms
* audit_log_group
* audit_log_perms
* audit_log_user

The original implementations fail when whitespace appears around the = sign in the configuration file, producing invalid paths and causing the checks to fail even on correctly configured systems.

**Problem Description**
Several scripts extract the audit log path using:
```
grep -E "^\s*log_file" "$AUDITD_CONF_FILE" | awk -F "=" '{print $2}'
```
This approach preserves leading whitespace. When auditd.conf contains:
```
log_file = /var/log/audit/audit.log
```
the extracted value becomes:
```
 /var/log/audit/audit.log
^ leading space
```
As a result:
dirname returns ' /var/log/audit' (with leading space)
stat and find operate on a non-existent path
Scripts fail with errors such as:
```
stat: cannot statx ' /var/log/audit': No such file or directory
find: ‘ /var/log/audit’: No such file or directory
```