### PR TITLE
Fix undefined variable LOADED_MODULE_NAME in disable_rds.sh and disable_tipc.sh

### DIFF
--- a/bin/hardening/disable_rds.sh
+++ b/bin/hardening/disable_rds.sh
@@ -57,9 +57,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_tipc.sh
+++ b/bin/hardening/disable_tipc.sh
@@ -57,9 +57,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 


### PR DESCRIPTION
This PR fixes a bug in disable_rds.sh and disable_tipc.sh where the script references an undefined variable: LOADED_MODULE_NAME.

When running the script, the following error occurs:
disable_rds.sh: line 60: LOADED_MODULE_NAME: unbound variable
disable_tipc.sh: line 60: LOADED_MODULE_NAME: unbound variable

The correct variable used in the script is MODULE_NAME. This change replaces LOADED_MODULE_NAME with MODULE_NAME to resolve the issue.

This fix allows the script to run without triggering an unbound variable error.