### PR TITLE
fix: replace undefined LOADED_MODULE_NAME with MODULE_NAME in apply() functions

### DIFF
--- a/bin/hardening/disable_cramfs.sh
+++ b/bin/hardening/disable_cramfs.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_dccp.sh
+++ b/bin/hardening/disable_dccp.sh
@@ -57,9 +57,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_freevxfs.sh
+++ b/bin/hardening/disable_freevxfs.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_hfs.sh
+++ b/bin/hardening/disable_hfs.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_hfsplus.sh
+++ b/bin/hardening/disable_hfsplus.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_jffs2.sh
+++ b/bin/hardening/disable_jffs2.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_rds.sh
+++ b/bin/hardening/disable_rds.sh
@@ -57,9 +57,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_sctp.sh
+++ b/bin/hardening/disable_sctp.sh
@@ -57,9 +57,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_squashfs.sh
+++ b/bin/hardening/disable_squashfs.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_tipc.sh
+++ b/bin/hardening/disable_tipc.sh
@@ -57,9 +57,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 

--- a/bin/hardening/disable_udf.sh
+++ b/bin/hardening/disable_udf.sh
@@ -55,9 +55,9 @@ apply() {
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 


### PR DESCRIPTION
Several kernel module hardening scripts used `$LOADED_MODULE_NAME` inside their `apply()` functions without ever defining it at the script level. With `set -u` active, this caused an immediate unbound variable crash (exit 1) any time a script ran in `enabled` mode.

The variable `LOADED_MODULE_NAME` is intentionally defined in `disable_usb_storage.sh` because the modprobe name (`usb-storage`) differs from the name as it appears in `/proc/modules` (`usb_storage`). The affected scripts have no such distinction — their module names are identical in both contexts — so the correct variable is `MODULE_NAME`, which is what `audit()` already used consistently in all of these files.

## Affected scripts

11 in `bin/hardening/`, 2 in `versions/default/`:

- `disable_cramfs`, `disable_dccp`, `disable_freevxfs`, `disable_hfs`, `disable_hfsplus`
- `disable_jffs2`, `disable_rds`, `disable_sctp`, `disable_squashfs`, `disable_tipc`, `disable_udf`
- `versions/default/1.1.1.5_disable_squashfs.sh`, `versions/default/1.1.1.6_disable_udf.sh`

## Root cause

Copy-paste from `disable_usb_storage.sh` without carrying over the `LOADED_MODULE_NAME` definition.
