### PR TITLE
fix: only report genuinely-installed packages in is_pkg_installed

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -676,8 +676,9 @@ apt_remove() {
 #
 
 is_pkg_installed() {
-    PKG_NAME=$1
-    if dpkg -s "$PKG_NAME" 2>/dev/null | grep -q '^Status: install '; then
+    local PKG_NAME=$1
+    # Match the real status field, not the desired-action field, so a residual "install" selection on an absent package is not counted as installed.
+    if dpkg-query -W -f='${db:Status-Status}' "$PKG_NAME" 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         debug "$PKG_NAME is installed"
         FNRET=0
     else

--- a/tests/hardening/audit_conf_group.sh
+++ b/tests/hardening/audit_conf_group.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_conf_owner.sh
+++ b/tests/hardening/audit_conf_owner.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_confs_perms.sh
+++ b/tests/hardening/audit_confs_perms.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_log_directory_perms.sh
+++ b/tests/hardening/audit_log_directory_perms.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_log_group.sh
+++ b/tests/hardening/audit_log_group.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_log_perms.sh
+++ b/tests/hardening/audit_log_perms.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_log_user.sh
+++ b/tests/hardening/audit_log_user.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_tools_group.sh
+++ b/tests/hardening/audit_tools_group.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_tools_owner.sh
+++ b/tests/hardening/audit_tools_owner.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/audit_tools_perms.sh
+++ b/tests/hardening/audit_tools_perms.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi

--- a/tests/hardening/auditd_running_config_same_on_disk.sh
+++ b/tests/hardening/auditd_running_config_same_on_disk.sh
@@ -2,7 +2,7 @@
 # run-shellcheck
 test_audit() {
     local test_install_package=1
-    if ! dpkg -s auditd 2>/dev/null | grep -q '^Status: install '; then
+    if ! dpkg-query -W -f='${db:Status-Status}' auditd 2>/dev/null | grep -Eqx 'installed|triggers-awaited|triggers-pending'; then
         apt install -y auditd
         test_install_package=0
     fi


### PR DESCRIPTION
## Summary

`is_pkg_installed()` reports packages as installed when they are not, because it keys off the dpkg **desired-action** field instead of the actual package status.

## Root cause

```sh
dpkg -s "$PKG_NAME" 2>/dev/null | grep -q '^Status: install '
```

The `Status:` line is `<desired-action> <error> <status>`. The pattern `^Status: install ` only checks the desired-action field, so it also matches packages that are **not installed** but still carry an `install` selection, e.g.:

- `install ok not-installed` (a leftover selection, e.g. after `dpkg --set-selections`)
- `install ok config-files`
- `install ok half-installed`

## Impact

Every package-based check is affected. In practice this shows up on `disable_http_server` (2.2.10) and `disable_http_proxy` (2.2.13): a host that once had `nginx`/`squid` and still carries a residual `install` selection gets a false `crit` even though the package is gone.

Reproduction:

```sh
echo "nginx install" | dpkg --set-selections   # residual selection, nothing installed
dpkg -s nginx | grep '^Status:'                 # -> Status: install ok not-installed
# disable_http_server now crits on nginx, which is not installed
```

## Fix

Query the real status field and match only the functionally-installed states:

```sh
dpkg-query -W -f='${db:Status-Status}' "$PKG_NAME" 2>/dev/null \
    | grep -Eqx 'installed|triggers-awaited|triggers-pending'
```

This is independent of the desired-action field, so:

- residual `install` selections on absent packages are no longer reported as installed;
- a held package (`hold ok installed`) is still correctly reported as installed;
- `triggers-awaited` / `triggers-pending` (functionally installed) are matched.

The same inline pattern was duplicated in the `auditd` test scenarios (used to decide whether to install `auditd` before the test) and is updated to the same idiom.

## How tested

- `shellcheck` and `shfmt -i 4` clean on all changed files.
- Full functional test suite (debian docker target) passes; the affected `auditd` and `disable_http_*` scenarios run green.
- Verified across the supported targets that `dpkg-query -W -f='${db:Status-Status}'` is available (dpkg ≥ 1.17).
