### PR TITLE
fix kernel module disabling scripts - unset variable (#324)

### DIFF
--- a/bin/hardening/disable_cramfs.sh
+++ b/bin/hardening/disable_cramfs.sh
@@ -22,11 +22,13 @@ MODULE_NAME="cramfs"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_dccp.sh
+++ b/bin/hardening/disable_dccp.sh
@@ -24,11 +24,13 @@ MODULE_NAME="dccp"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -36,11 +38,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -53,18 +55,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_freevxfs.sh
+++ b/bin/hardening/disable_freevxfs.sh
@@ -22,11 +22,13 @@ MODULE_NAME="freevxfs"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_hfs.sh
+++ b/bin/hardening/disable_hfs.sh
@@ -22,11 +22,13 @@ MODULE_NAME="hfs"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_hfsplus.sh
+++ b/bin/hardening/disable_hfsplus.sh
@@ -22,11 +22,13 @@ MODULE_NAME="hfsplus"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_jffs2.sh
+++ b/bin/hardening/disable_jffs2.sh
@@ -22,11 +22,13 @@ MODULE_NAME="jffs2"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_rds.sh
+++ b/bin/hardening/disable_rds.sh
@@ -24,11 +24,13 @@ MODULE_NAME="rds"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -36,11 +38,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -53,18 +55,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_sctp.sh
+++ b/bin/hardening/disable_sctp.sh
@@ -24,11 +24,13 @@ MODULE_NAME="sctp"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -36,11 +38,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -53,18 +55,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_squashfs.sh
+++ b/bin/hardening/disable_squashfs.sh
@@ -22,11 +22,13 @@ MODULE_NAME="squashfs"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_tipc.sh
+++ b/bin/hardening/disable_tipc.sh
@@ -24,11 +24,13 @@ MODULE_NAME="tipc"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -36,11 +38,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -53,18 +55,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_udf.sh
+++ b/bin/hardening/disable_udf.sh
@@ -22,11 +22,13 @@ MODULE_NAME="udf"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
             crit "$MODULE_NAME is loaded!"
         else
@@ -34,11 +36,11 @@ audit() {
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -51,18 +53,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"

--- a/bin/hardening/disable_usb_storage.sh
+++ b/bin/hardening/disable_usb_storage.sh
@@ -27,23 +27,25 @@ LOADED_MODULE_NAME="usb_storage"
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing or disable this check!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$MODULE_NAME is loaded!"
         else
-            ok "$LOADED_MODULE_NAME is not loaded"
+            ok "$MODULE_NAME is not loaded"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 0 ]; then
                 ok "$MODULE_NAME is disabled in the modprobe configuration"
             else
-                is_kernel_module_available "$KERNEL_OPTION"
+                is_kernel_module_available "$CHECKED_MODULE"
                 if [ "$FNRET" -eq 0 ]; then
                     crit "$MODULE_NAME is available in some kernel config, but not disabled"
                 else
@@ -56,18 +58,20 @@ audit() {
 
 # This function will be called if the script status is on enabled mode
 apply() {
+    CHECKED_MODULE="${LOADED_MODULE_NAME:-$MODULE_NAME}"
+
     if [ "$IS_CONTAINER" -eq 1 ]; then
         # In an unprivileged container, the kernel modules are host dependent, so you should consider enforcing it
         ok "Container detected, consider host enforcing!"
     else
-        is_kernel_module_loaded "$KERNEL_OPTION" "$LOADED_MODULE_NAME"
+        is_kernel_module_loaded "$KERNEL_OPTION" "$CHECKED_MODULE"
         if [ "$FNRET" -eq 0 ]; then # 0 means true in bash, so it IS activated
-            crit "$LOADED_MODULE_NAME is loaded!"
+            crit "$CHECKED_MODULE is loaded!"
             warn "I wont unload the module, unload it manually or recompile the kernel if needed"
         fi
 
         if [ "$IS_MONOLITHIC_KERNEL" -eq 1 ]; then
-            is_kernel_module_disabled "$MODULE_NAME"
+            is_kernel_module_disabled "$CHECKED_MODULE"
             if [ "$FNRET" -eq 1 ]; then
                 echo "install $MODULE_NAME /bin/true" >>/etc/modprobe.d/"$MODULE_NAME".conf
                 info "$MODULE_NAME has been disabled in the modprobe configuration"


### PR DESCRIPTION
As mentionned in issue [#324](https://github.com/ovh/debian-cis/issues/324) and PR [#325](https://github.com/ovh/debian-cis/pull/325), the scripts are currently raising a "variable not found" error.

Instead of adding the "LOADED_MODULE_NAME" everywhere, as proposed in PR [#325](https://github.com/ovh/debian-cis/pull/325) we fix it with variable substitution : the purpose of "LOADED_MODULE_NAME" is to make the distinction between the module as in modprobe, and its value in the kernel once loaded.