### PR TITLE
fix: missing link for config files

### DIFF
--- a/lib/main.sh
+++ b/lib/main.sh
@@ -116,6 +116,8 @@ if [ "$conf_write_allowed" -eq 0 ]; then
         # make sure the existing link points to the correct file
         elif [ -L "${CIS_CONF_DIR}"/conf.d/"$cfg_link" ] && [[ $(readlink -f "${CIS_CONF_DIR}"/conf.d/"$cfg_link") != "${CIS_CONF_DIR}"/conf.d/"$cfg_file" ]]; then
             ln -fs "${CIS_CONF_DIR}"/conf.d/"$cfg_file" "${CIS_CONF_DIR}"/conf.d/"$cfg_link"
+        else
+            ln -s "${CIS_CONF_DIR}"/conf.d/"$cfg_file" "${CIS_CONF_DIR}"/conf.d/"$cfg_link"
         fi
     fi
 else


### PR DESCRIPTION
Since [this commit](https://github.com/ovh/debian-cis/pull/331/changes/90fd5337028526444e724294cf0c77e5c04752aa), config links are not written anymore if not already exists