### PR TITLE
update scripts to debian 12 standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ For checks that are intentionally **manual remediation only** (script `apply()` 
 - Restore modified config files at end of test
 - In tests, if `${script}` (or other harness vars) is used in local variable assignments, add `# shellcheck disable=2154` immediately above those lines.
 - If non-compliant state cannot be created (config absent), use `skip` + `register_test`/`run` inside the conditional block
+- For dependency-aware package/service tests, if a non-compliant state cannot be reliably created in the current environment (for example package is required and units cannot be forced to enabled/active), skip the remediation path with `skip` + `register_test`/`run` instead of forcing `retvalshouldbe 1`
 - Do not use `mount`/`remount` in containers; skip those tests with a container check
 - For scripts interacting with audit runtime (auditctl/augenrules), check `auditctl -s` availability and skip if not present.
 - For scripts interacting with systemd, use `is_systemctl_running` and skip when systemd is not running.

--- a/bin/hardening/disable_automounting.sh
+++ b/bin/hardening/disable_automounting.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Disable Automounting (Scored)
+# Ensure autofs services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,30 +15,85 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=2
 # shellcheck disable=2034
-DESCRIPTION="Disable automounting of devices."
+DESCRIPTION="Ensure autofs services are not in use."
 
-SERVICE_NAME="autofs"
+PACKAGE='autofs'
+SERVICE='autofs.service'
+
+# Global state (0=true/success, 1=false/failure)
+AUTOMOUNT_PKG_INSTALLED=1
+AUTOMOUNT_PKG_IS_DEPENDENCY=1
+AUTOMOUNT_SERVICE_ENABLED=1
+AUTOMOUNT_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    info "Checking if $SERVICE_NAME is enabled"
-    is_service_enabled "$SERVICE_NAME"
-    if [ "$FNRET" = 0 ]; then
-        crit "$SERVICE_NAME is enabled"
+    AUTOMOUNT_PKG_INSTALLED=1
+    AUTOMOUNT_PKG_IS_DEPENDENCY=1
+    AUTOMOUNT_SERVICE_ENABLED=1
+    AUTOMOUNT_SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        AUTOMOUNT_PKG_INSTALLED=0
     else
-        ok "$SERVICE_NAME is disabled"
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        AUTOMOUNT_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$AUTOMOUNT_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        AUTOMOUNT_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        AUTOMOUNT_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$AUTOMOUNT_SERVICE_ENABLED" -ne 0 ] && [ "$AUTOMOUNT_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    info "Checking if $SERVICE_NAME is enabled"
-    is_service_enabled "$SERVICE_NAME"
-    if [ "$FNRET" = 0 ]; then
-        info "Disabling $SERVICE_NAME"
-        manage_service disable "$SERVICE_NAME"
+    if [ "$AUTOMOUNT_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$AUTOMOUNT_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$AUTOMOUNT_SERVICE_ENABLED" -eq 0 ] || [ "$AUTOMOUNT_SERVICE_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
     else
-        ok "$SERVICE_NAME is disabled"
+        ok "$SERVICE already not enabled/active"
     fi
 }
 

--- a/bin/hardening/disable_avahi_server.sh
+++ b/bin/hardening/disable_avahi_server.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure Avahi Server is not enabled (Scored)
+# Ensure avahi daemon services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,34 +15,107 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure Avahi server is not enabled."
+DESCRIPTION="Ensure avahi daemon services are not in use."
 
-PACKAGES='avahi-daemon libavahi-common-data libavahi-common3 libavahi-core7'
+PACKAGE='avahi-daemon'
+SERVICE='avahi-daemon.service'
+SOCKET='avahi-daemon.socket'
+
+# Global state (0=true/success, 1=false/failure)
+AVAHI_SERVER_PKG_INSTALLED=1
+AVAHI_SERVER_PKG_IS_DEPENDENCY=1
+AVAHI_SERVER_SERVICE_ENABLED=1
+AVAHI_SERVER_SERVICE_ACTIVE=1
+AVAHI_SERVER_SOCKET_ENABLED=1
+AVAHI_SERVER_SOCKET_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    AVAHI_SERVER_PKG_INSTALLED=1
+    AVAHI_SERVER_PKG_IS_DEPENDENCY=1
+    AVAHI_SERVER_SERVICE_ENABLED=1
+    AVAHI_SERVER_SERVICE_ACTIVE=1
+    AVAHI_SERVER_SOCKET_ENABLED=1
+    AVAHI_SERVER_SOCKET_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        AVAHI_SERVER_PKG_INSTALLED=0
+    else
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        AVAHI_SERVER_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$AVAHI_SERVER_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        AVAHI_SERVER_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        AVAHI_SERVER_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    is_socket_enabled "$SOCKET"
+    if [ "$FNRET" -eq 0 ]; then
+        AVAHI_SERVER_SOCKET_ENABLED=0
+        crit "$SOCKET is enabled"
+    fi
+
+    is_socket_active "$SOCKET"
+    if [ "$FNRET" -eq 0 ]; then
+        AVAHI_SERVER_SOCKET_ACTIVE=0
+        crit "$SOCKET is active"
+    fi
+
+    if [ "$AVAHI_SERVER_SERVICE_ENABLED" -ne 0 ] &&
+        [ "$AVAHI_SERVER_SERVICE_ACTIVE" -ne 0 ] &&
+        [ "$AVAHI_SERVER_SOCKET_ENABLED" -ne 0 ] &&
+        [ "$AVAHI_SERVER_SOCKET_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE/$SOCKET are not enabled/active"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$AVAHI_SERVER_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$AVAHI_SERVER_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE and $SOCKET"
+        return
+    fi
+
+    if [ "$AVAHI_SERVER_SERVICE_ENABLED" -eq 0 ] || [ "$AVAHI_SERVER_SERVICE_ACTIVE" -eq 0 ] ||
+        [ "$AVAHI_SERVER_SOCKET_ENABLED" -eq 0 ] || [ "$AVAHI_SERVER_SOCKET_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE and $SOCKET"
+        systemctl stop "$SOCKET" "$SERVICE" || true
+        systemctl mask "$SOCKET" "$SERVICE"
+    else
+        ok "$SERVICE and $SOCKET already not enabled/active"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_http_proxy.sh
+++ b/bin/hardening/disable_http_proxy.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure HTTP Proxy Server is not enabled (Scored)
+# Ensure web proxy server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,88 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure HTTP-proxy is not enabled."
+DESCRIPTION="Ensure web proxy server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=http
 
-PACKAGES='squid3 squid'
+PACKAGE='squid'
+SERVICE='squid.service'
+
+# Global state (0=true/success, 1=false/failure)
+HTTP_PROXY_PKG_INSTALLED=1
+HTTP_PROXY_PKG_IS_DEPENDENCY=1
+HTTP_PROXY_SERVICE_ENABLED=1
+HTTP_PROXY_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    HTTP_PROXY_PKG_INSTALLED=1
+    HTTP_PROXY_PKG_IS_DEPENDENCY=1
+    HTTP_PROXY_SERVICE_ENABLED=1
+    HTTP_PROXY_SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        HTTP_PROXY_PKG_INSTALLED=0
+    else
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        HTTP_PROXY_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$HTTP_PROXY_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        HTTP_PROXY_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        HTTP_PROXY_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$HTTP_PROXY_SERVICE_ENABLED" -ne 0 ] && [ "$HTTP_PROXY_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$HTTP_PROXY_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$HTTP_PROXY_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$HTTP_PROXY_SERVICE_ENABLED" -eq 0 ] || [ "$HTTP_PROXY_SERVICE_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
+    else
+        ok "$SERVICE already not enabled/active"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_http_server.sh
+++ b/bin/hardening/disable_http_server.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure HTTP Server is not enabled (Scored)
+# Ensure web server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,37 +15,183 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure HTTP server is not enabled."
+DESCRIPTION="Ensure web server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=http
 
-# Based on aptitude search '~Phttpd'
-PACKAGES='nginx apache2 lighttpd micro-httpd mini-httpd yaws boa bozohttpd'
+PACKAGE_APACHE='apache2'
+PACKAGE_NGINX='nginx'
+SERVICE_APACHE='apache2.service'
+SOCKET_APACHE='apache2.socket'
+SERVICE_NGINX='nginx.service'
+
+# Global state (0=true/success, 1=false/failure)
+HTTP_SERVER_APACHE_INSTALLED=1
+HTTP_SERVER_APACHE_IS_DEPENDENCY=1
+HTTP_SERVER_APACHE_SERVICE_ENABLED=1
+HTTP_SERVER_APACHE_SERVICE_ACTIVE=1
+HTTP_SERVER_APACHE_SOCKET_ENABLED=1
+HTTP_SERVER_APACHE_SOCKET_ACTIVE=1
+
+HTTP_SERVER_NGINX_INSTALLED=1
+HTTP_SERVER_NGINX_IS_DEPENDENCY=1
+HTTP_SERVER_NGINX_SERVICE_ENABLED=1
+HTTP_SERVER_NGINX_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
+    HTTP_SERVER_APACHE_INSTALLED=1
+    HTTP_SERVER_APACHE_IS_DEPENDENCY=1
+    HTTP_SERVER_APACHE_SERVICE_ENABLED=1
+    HTTP_SERVER_APACHE_SERVICE_ACTIVE=1
+    HTTP_SERVER_APACHE_SOCKET_ENABLED=1
+    HTTP_SERVER_APACHE_SOCKET_ACTIVE=1
+
+    HTTP_SERVER_NGINX_INSTALLED=1
+    HTTP_SERVER_NGINX_IS_DEPENDENCY=1
+    HTTP_SERVER_NGINX_SERVICE_ENABLED=1
+    HTTP_SERVER_NGINX_SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE_APACHE"
+    if [ "$FNRET" -eq 0 ]; then
+        HTTP_SERVER_APACHE_INSTALLED=0
+    fi
+
+    is_pkg_installed "$PACKAGE_NGINX"
+    if [ "$FNRET" -eq 0 ]; then
+        HTTP_SERVER_NGINX_INSTALLED=0
+    fi
+
+    if [ "$HTTP_SERVER_APACHE_INSTALLED" -ne 0 ] && [ "$HTTP_SERVER_NGINX_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE_APACHE is not installed"
+        ok "$PACKAGE_NGINX is not installed"
+        return
+    fi
+
+    if [ "$HTTP_SERVER_APACHE_INSTALLED" -eq 0 ]; then
+        is_pkg_a_dependency "$PACKAGE_APACHE"
+        if [ "$FNRET" -eq 0 ]; then
+            HTTP_SERVER_APACHE_IS_DEPENDENCY=0
         fi
-    done
+
+        if [ "$HTTP_SERVER_APACHE_IS_DEPENDENCY" -ne 0 ]; then
+            crit "$PACKAGE_APACHE is installed and not a dependency"
+        else
+            is_service_enabled "$SERVICE_APACHE"
+            if [ "$FNRET" -eq 0 ]; then
+                HTTP_SERVER_APACHE_SERVICE_ENABLED=0
+                crit "$SERVICE_APACHE is enabled"
+            fi
+
+            is_service_active "$SERVICE_APACHE"
+            if [ "$FNRET" -eq 0 ]; then
+                HTTP_SERVER_APACHE_SERVICE_ACTIVE=0
+                crit "$SERVICE_APACHE is active"
+            fi
+
+            is_socket_enabled "$SOCKET_APACHE"
+            if [ "$FNRET" -eq 0 ]; then
+                HTTP_SERVER_APACHE_SOCKET_ENABLED=0
+                crit "$SOCKET_APACHE is enabled"
+            fi
+
+            is_socket_active "$SOCKET_APACHE"
+            if [ "$FNRET" -eq 0 ]; then
+                HTTP_SERVER_APACHE_SOCKET_ACTIVE=0
+                crit "$SOCKET_APACHE is active"
+            fi
+
+            if [ "$HTTP_SERVER_APACHE_SERVICE_ENABLED" -ne 0 ] &&
+                [ "$HTTP_SERVER_APACHE_SERVICE_ACTIVE" -ne 0 ] &&
+                [ "$HTTP_SERVER_APACHE_SOCKET_ENABLED" -ne 0 ] &&
+                [ "$HTTP_SERVER_APACHE_SOCKET_ACTIVE" -ne 0 ]; then
+                ok "$PACKAGE_APACHE is used as a dependency and $SERVICE_APACHE/$SOCKET_APACHE are not enabled/active"
+            fi
+        fi
+    fi
+
+    if [ "$HTTP_SERVER_NGINX_INSTALLED" -eq 0 ]; then
+        is_pkg_a_dependency "$PACKAGE_NGINX"
+        if [ "$FNRET" -eq 0 ]; then
+            HTTP_SERVER_NGINX_IS_DEPENDENCY=0
+        fi
+
+        if [ "$HTTP_SERVER_NGINX_IS_DEPENDENCY" -ne 0 ]; then
+            crit "$PACKAGE_NGINX is installed and not a dependency"
+        else
+            is_service_enabled "$SERVICE_NGINX"
+            if [ "$FNRET" -eq 0 ]; then
+                HTTP_SERVER_NGINX_SERVICE_ENABLED=0
+                crit "$SERVICE_NGINX is enabled"
+            fi
+
+            is_service_active "$SERVICE_NGINX"
+            if [ "$FNRET" -eq 0 ]; then
+                HTTP_SERVER_NGINX_SERVICE_ACTIVE=0
+                crit "$SERVICE_NGINX is active"
+            fi
+
+            if [ "$HTTP_SERVER_NGINX_SERVICE_ENABLED" -ne 0 ] && [ "$HTTP_SERVER_NGINX_SERVICE_ACTIVE" -ne 0 ]; then
+                ok "$PACKAGE_NGINX is used as a dependency and $SERVICE_NGINX is not enabled/active"
+            fi
+        fi
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
+    local removed_any
+    removed_any=1
+
+    if [ "$HTTP_SERVER_APACHE_INSTALLED" -eq 0 ] && [ "$HTTP_SERVER_APACHE_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE_APACHE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE_APACHE" -y
+        removed_any=0
+    fi
+
+    if [ "$HTTP_SERVER_NGINX_INSTALLED" -eq 0 ] && [ "$HTTP_SERVER_NGINX_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE_NGINX is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE_NGINX" -y
+        removed_any=0
+    fi
+
+    if [ "$removed_any" -eq 0 ]; then
+        apt-get autoremove -y
+    fi
+
+    if [ "$HTTP_SERVER_APACHE_INSTALLED" -eq 0 ] && [ "$HTTP_SERVER_APACHE_IS_DEPENDENCY" -eq 0 ]; then
+        is_systemctl_running
+        if [ "$FNRET" -ne 0 ]; then
+            warn "systemd not running, cannot stop/mask $SERVICE_APACHE and $SOCKET_APACHE"
+        elif [ "$HTTP_SERVER_APACHE_SERVICE_ENABLED" -eq 0 ] ||
+            [ "$HTTP_SERVER_APACHE_SERVICE_ACTIVE" -eq 0 ] ||
+            [ "$HTTP_SERVER_APACHE_SOCKET_ENABLED" -eq 0 ] ||
+            [ "$HTTP_SERVER_APACHE_SOCKET_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE_APACHE and $SOCKET_APACHE"
+            systemctl stop "$SOCKET_APACHE" "$SERVICE_APACHE" || true
+            systemctl mask "$SOCKET_APACHE" "$SERVICE_APACHE"
         else
-            ok "$PACKAGE is absent"
+            ok "$SERVICE_APACHE and $SOCKET_APACHE already not enabled/active"
         fi
-    done
+    fi
+
+    if [ "$HTTP_SERVER_NGINX_INSTALLED" -eq 0 ] && [ "$HTTP_SERVER_NGINX_IS_DEPENDENCY" -eq 0 ]; then
+        is_systemctl_running
+        if [ "$FNRET" -ne 0 ]; then
+            warn "systemd not running, cannot stop/mask $SERVICE_NGINX"
+        elif [ "$HTTP_SERVER_NGINX_SERVICE_ENABLED" -eq 0 ] || [ "$HTTP_SERVER_NGINX_SERVICE_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE_NGINX"
+            systemctl stop "$SERVICE_NGINX" || true
+            systemctl mask "$SERVICE_NGINX"
+        else
+            ok "$SERVICE_NGINX already not enabled/active"
+        fi
+    fi
+
+    if [ "$HTTP_SERVER_APACHE_INSTALLED" -ne 0 ] && [ "$HTTP_SERVER_NGINX_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE_APACHE is not installed"
+        ok "$PACKAGE_NGINX is not installed"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_nis.sh
+++ b/bin/hardening/disable_nis.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure NIS Server is not enabled (Scored)
+# Ensure nis server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,34 +15,86 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Disable NIS Server."
+DESCRIPTION="Ensure nis server services are not in use."
 
-PACKAGES='nis'
+PACKAGE='ypserv'
+SERVICE='ypserv.service'
+
+# Global state (0 = true/success, 1 = false/failure)
+DISABLE_NIS_PKG_INSTALLED=1
+DISABLE_NIS_PKG_IS_DEPENDENCY=1
+DISABLE_NIS_SERVICE_ENABLED=1
+DISABLE_NIS_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    DISABLE_NIS_PKG_INSTALLED=1
+    DISABLE_NIS_PKG_IS_DEPENDENCY=1
+    DISABLE_NIS_SERVICE_ENABLED=1
+    DISABLE_NIS_SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_NIS_PKG_INSTALLED=0
+    else
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_NIS_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$DISABLE_NIS_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_NIS_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_NIS_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$DISABLE_NIS_SERVICE_ENABLED" -ne 0 ] && [ "$DISABLE_NIS_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$DISABLE_NIS_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$DISABLE_NIS_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$DISABLE_NIS_SERVICE_ACTIVE" -eq 0 ] || [ "$DISABLE_NIS_SERVICE_ENABLED" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
+    else
+        ok "$SERVICE already not enabled/active"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_print_server.sh
+++ b/bin/hardening/disable_print_server.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure CUPS is not enabled (Scored)
+# Ensure print server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,109 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure print server (Common Unix Print System) is not enabled."
+DESCRIPTION="Ensure print server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=cups
 
-PACKAGES='libcups2 libcupscgi1 libcupsimage2 libcupsmime1 libcupsppdc1 cups-common cups-client cups-ppdc libcupsfilters1 cups-filters cups'
+PACKAGE='cups'
+SERVICE='cups.service'
+SOCKET='cups.socket'
+
+# Global state (0 = true/success, 1 = false/failure)
+PRINT_SERVER_PKG_INSTALLED=1
+PRINT_SERVER_PKG_IS_DEPENDENCY=1
+PRINT_SERVER_SERVICE_ENABLED=1
+PRINT_SERVER_SERVICE_ACTIVE=1
+PRINT_SERVER_SOCKET_ENABLED=1
+PRINT_SERVER_SOCKET_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    PRINT_SERVER_PKG_INSTALLED=1
+    PRINT_SERVER_PKG_IS_DEPENDENCY=1
+    PRINT_SERVER_SERVICE_ENABLED=1
+    PRINT_SERVER_SERVICE_ACTIVE=1
+    PRINT_SERVER_SOCKET_ENABLED=1
+    PRINT_SERVER_SOCKET_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PRINT_SERVER_PKG_INSTALLED=0
+    else
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PRINT_SERVER_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$PRINT_SERVER_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        PRINT_SERVER_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        PRINT_SERVER_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    is_socket_enabled "$SOCKET"
+    if [ "$FNRET" -eq 0 ]; then
+        PRINT_SERVER_SOCKET_ENABLED=0
+        crit "$SOCKET is enabled"
+    fi
+
+    is_socket_active "$SOCKET"
+    if [ "$FNRET" -eq 0 ]; then
+        PRINT_SERVER_SOCKET_ACTIVE=0
+        crit "$SOCKET is active"
+    fi
+
+    if [ "$PRINT_SERVER_SERVICE_ENABLED" -ne 0 ] &&
+        [ "$PRINT_SERVER_SERVICE_ACTIVE" -ne 0 ] &&
+        [ "$PRINT_SERVER_SOCKET_ENABLED" -ne 0 ] &&
+        [ "$PRINT_SERVER_SOCKET_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE/$SOCKET are not enabled/active"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$PRINT_SERVER_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$PRINT_SERVER_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE and $SOCKET"
+        return
+    fi
+
+    if [ "$PRINT_SERVER_SERVICE_ENABLED" -eq 0 ] || [ "$PRINT_SERVER_SERVICE_ACTIVE" -eq 0 ] ||
+        [ "$PRINT_SERVER_SOCKET_ENABLED" -eq 0 ] || [ "$PRINT_SERVER_SOCKET_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE and $SOCKET"
+        systemctl stop "$SERVICE" "$SOCKET" || true
+        systemctl mask "$SERVICE" "$SOCKET"
+    else
+        ok "$SERVICE and $SOCKET already not enabled/active"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_rsync.sh
+++ b/bin/hardening/disable_rsync.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure rsync service is not enabled (Scored)
+# Ensure rsync services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,46 +15,87 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure rsync service is not enabled."
+DESCRIPTION="Ensure rsync services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=rsync
 
 PACKAGE='rsync'
-RSYNC_DEFAULT_PATTERN='RSYNC_ENABLE=false'
-RSYNC_DEFAULT_FILE='/etc/default/rsync'
-RSYNC_DEFAULT_PATTERN_TO_SEARCH='RSYNC_ENABLE=true'
+SERVICE='rsync.service'
+
+# Global state (0=true/success, 1=false/failure)
+DISABLE_RSYNC_PKG_INSTALLED=1
+DISABLE_RSYNC_PKG_IS_DEPENDENCY=1
+DISABLE_RSYNC_SERVICE_ENABLED=1
+DISABLE_RSYNC_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    DISABLE_RSYNC_PKG_INSTALLED=1
+    DISABLE_RSYNC_PKG_IS_DEPENDENCY=1
+    DISABLE_RSYNC_SERVICE_ENABLED=1
+    DISABLE_RSYNC_SERVICE_ACTIVE=1
+
     is_pkg_installed "$PACKAGE"
-    if [ "$FNRET" != 0 ]; then
-        ok "$PACKAGE is not installed"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_RSYNC_PKG_INSTALLED=0
     else
-        ok "$PACKAGE is installed, checking configuration"
-        does_pattern_exist_in_file "$RSYNC_DEFAULT_FILE" "^$RSYNC_DEFAULT_PATTERN"
-        if [ "$FNRET" != 0 ]; then
-            crit "$RSYNC_DEFAULT_PATTERN not found in $RSYNC_DEFAULT_FILE"
-        else
-            ok "$RSYNC_DEFAULT_PATTERN found in $RSYNC_DEFAULT_FILE"
-        fi
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_RSYNC_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$DISABLE_RSYNC_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_RSYNC_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_RSYNC_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$DISABLE_RSYNC_SERVICE_ENABLED" -ne 0 ] && [ "$DISABLE_RSYNC_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    is_pkg_installed "$PACKAGE"
-    if [ "$FNRET" != 0 ]; then
+    if [ "$DISABLE_RSYNC_PKG_INSTALLED" -ne 0 ]; then
         ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$DISABLE_RSYNC_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$DISABLE_RSYNC_SERVICE_ENABLED" -eq 0 ] || [ "$DISABLE_RSYNC_SERVICE_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
     else
-        ok "$PACKAGE is installed, checking configuration"
-        does_pattern_exist_in_file "$RSYNC_DEFAULT_FILE" "^$RSYNC_DEFAULT_PATTERN"
-        if [ "$FNRET" != 0 ]; then
-            warn "$RSYNC_DEFAULT_PATTERN not found in $RSYNC_DEFAULT_FILE, adding it"
-            backup_file "$RSYNC_DEFAULT_FILE"
-            replace_in_file "$RSYNC_DEFAULT_FILE" "$RSYNC_DEFAULT_PATTERN_TO_SEARCH" "$RSYNC_DEFAULT_PATTERN"
-        else
-            ok "$RSYNC_DEFAULT_PATTERN found in $RSYNC_DEFAULT_FILE"
-        fi
+        ok "$SERVICE already not enabled/active"
     fi
 }
 

--- a/bin/hardening/disable_samba.sh
+++ b/bin/hardening/disable_samba.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure Samba is not enabled (Scored)
+# Ensure samba file server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,49 +15,87 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure Samba is not enabled."
+DESCRIPTION="Ensure samba file server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=samba
 
-PACKAGES='samba'
-SERVICE='smbd'
+PACKAGE='samba'
+SERVICE='smbd.service'
+
+# Global state (0=true/success, 1=false/failure)
+DISABLE_SAMBA_PKG_INSTALLED=1
+DISABLE_SAMBA_PKG_IS_DEPENDENCY=1
+DISABLE_SAMBA_SERVICE_ENABLED=1
+DISABLE_SAMBA_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
-    is_service_enabled "$SERVICE"
-    if [ "$FNRET" = 0 ]; then
-        crit "Service $SERVICE is enabled!"
+    DISABLE_SAMBA_PKG_INSTALLED=1
+    DISABLE_SAMBA_PKG_IS_DEPENDENCY=1
+    DISABLE_SAMBA_SERVICE_ENABLED=1
+    DISABLE_SAMBA_SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_SAMBA_PKG_INSTALLED=0
     else
-        ok "Service $SERVICE is disabled"
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_SAMBA_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$DISABLE_SAMBA_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_SAMBA_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        DISABLE_SAMBA_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$DISABLE_SAMBA_SERVICE_ENABLED" -ne 0 ] && [ "$DISABLE_SAMBA_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
-    is_service_enabled "$SERVICE"
-    if [ "$FNRET" = 0 ]; then
-        crit "Service $SERVICE is enabled!"
-        systemctl disable "$SERVICE"
+    if [ "$DISABLE_SAMBA_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$DISABLE_SAMBA_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$DISABLE_SAMBA_SERVICE_ENABLED" -eq 0 ] || [ "$DISABLE_SAMBA_SERVICE_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
     else
-        ok "Service $SERVICE is disabled"
+        ok "$SERVICE already not enabled/active"
     fi
 }
 

--- a/bin/hardening/disable_snmp_server.sh
+++ b/bin/hardening/disable_snmp_server.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure SNMP Server is not enabled (Scored)
+# Ensure snmp services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,88 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Enure SNMP server is not enabled."
+DESCRIPTION="Ensure snmp services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=snmp
 
-PACKAGES='snmpd'
+PACKAGE='snmpd'
+SERVICE='snmpd.service'
+
+# Global state (0=true/success, 1=false/failure)
+SNMP_SERVER_PKG_INSTALLED=1
+SNMP_SERVER_PKG_IS_DEPENDENCY=1
+SNMP_SERVER_SERVICE_ENABLED=1
+SNMP_SERVER_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    SNMP_SERVER_PKG_INSTALLED=1
+    SNMP_SERVER_PKG_IS_DEPENDENCY=1
+    SNMP_SERVER_SERVICE_ENABLED=1
+    SNMP_SERVER_SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        SNMP_SERVER_PKG_INSTALLED=0
+    else
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        SNMP_SERVER_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$SNMP_SERVER_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SNMP_SERVER_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SNMP_SERVER_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$SNMP_SERVER_SERVICE_ENABLED" -ne 0 ] && [ "$SNMP_SERVER_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$SNMP_SERVER_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$SNMP_SERVER_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$SNMP_SERVER_SERVICE_ENABLED" -eq 0 ] || [ "$SNMP_SERVER_SERVICE_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
+    else
+        ok "$SERVICE already not enabled/active"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_xinetd.sh
+++ b/bin/hardening/disable_xinetd.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure xinetd is not enabled (Scored)
+# Ensure xinetd services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,29 +15,85 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure xinetd is not enabled."
+DESCRIPTION="Ensure xinetd services are not in use."
 
 PACKAGE='xinetd'
+SERVICE='xinetd.service'
+
+# Global state (0=true/success, 1=false/failure)
+XINETD_PKG_INSTALLED=1
+XINETD_PKG_IS_DEPENDENCY=1
+XINETD_SERVICE_ENABLED=1
+XINETD_SERVICE_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
+    XINETD_PKG_INSTALLED=1
+    XINETD_PKG_IS_DEPENDENCY=1
+    XINETD_SERVICE_ENABLED=1
+    XINETD_SERVICE_ACTIVE=1
+
     is_pkg_installed "$PACKAGE"
-    if [ "$FNRET" = 0 ]; then
-        crit "$PACKAGE is installed"
+    if [ "$FNRET" -eq 0 ]; then
+        XINETD_PKG_INSTALLED=0
     else
-        ok "$PACKAGE is absent"
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        XINETD_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$XINETD_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        XINETD_SERVICE_ENABLED=0
+        crit "$SERVICE is enabled"
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        XINETD_SERVICE_ACTIVE=0
+        crit "$SERVICE is active"
+    fi
+
+    if [ "$XINETD_SERVICE_ENABLED" -ne 0 ] && [ "$XINETD_SERVICE_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE is not enabled/active"
     fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    is_pkg_installed "$PACKAGE"
-    if [ "$FNRET" = 0 ]; then
-        warn "$PACKAGE is installed, purging"
+    if [ "$XINETD_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$XINETD_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
         apt-get purge "$PACKAGE" -y
-        apt-get autoremove
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE"
+        return
+    fi
+
+    if [ "$XINETD_SERVICE_ENABLED" -eq 0 ] || [ "$XINETD_SERVICE_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE"
+        systemctl stop "$SERVICE" || true
+        systemctl mask "$SERVICE"
     else
-        ok "$PACKAGE is absent"
+        ok "$SERVICE already not enabled/active"
     fi
 }
 

--- a/tests/hardening/disable_automounting.sh
+++ b/tests/hardening/disable_automounting.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show autofs 2>/dev/null | grep -q '^Package: autofs$'; then
+        describe "autofs package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install autofs"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y autofs || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask autofs.service >/dev/null 2>&1 || true
+            systemctl enable autofs.service >/dev/null 2>&1 || true
+            systemctl start autofs.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant autofs state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y autofs || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y autofs || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_avahi_server.sh
+++ b/tests/hardening/disable_avahi_server.sh
@@ -1,16 +1,56 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show avahi-daemon 2>/dev/null | grep -q '^Package: avahi-daemon$'; then
+        describe "avahi-daemon package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install avahi-daemon"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y avahi-daemon || true
+
+    # Ensure we can actually create a non-compliant state:
+    # - If package is not a dependency, audit already returns non-compliant.
+    # - If package is a dependency, try to enable/start service and socket.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask avahi-daemon.socket avahi-daemon.service >/dev/null 2>&1 || true
+            systemctl enable avahi-daemon.socket avahi-daemon.service >/dev/null 2>&1 || true
+            systemctl start avahi-daemon.socket avahi-daemon.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant avahi state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y avahi-daemon || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y avahi-daemon || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_http_proxy.sh
+++ b/tests/hardening/disable_http_proxy.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show squid 2>/dev/null | grep -q '^Package: squid$'; then
+        describe "squid package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install squid"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y squid || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask squid.service >/dev/null 2>&1 || true
+            systemctl enable squid.service >/dev/null 2>&1 || true
+            systemctl start squid.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant squid state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y squid || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y squid || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_http_server.sh
+++ b/tests/hardening/disable_http_server.sh
@@ -1,16 +1,111 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    local apache_available nginx_available
+    apache_available=1
+    nginx_available=1
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    if apt-cache show apache2 2>/dev/null | grep -q '^Package: apache2$'; then
+        apache_available=0
+    fi
+    if apt-cache show nginx 2>/dev/null | grep -q '^Package: nginx$'; then
+        nginx_available=0
+    fi
+
+    if [ "$apache_available" -ne 0 ] && [ "$nginx_available" -ne 0 ]; then
+        describe "apache2 and nginx packages are unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
+
+    if [ "$apache_available" -eq 0 ]; then
+        describe "Prepare non-compliant state - install apache2"
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apache2 || true
+
+        # Ensure we can actually create a non-compliant state.
+        if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+            if systemctl >/dev/null 2>&1; then
+                systemctl unmask apache2.socket apache2.service >/dev/null 2>&1 || true
+                systemctl enable apache2.socket apache2.service >/dev/null 2>&1 || true
+                systemctl start apache2.socket apache2.service >/dev/null 2>&1 || true
+            fi
+        fi
+
+        if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+            describe "Unable to create a non-compliant apache2 state - skipping remediation path"
+            skip
+            register_test retvalshouldbe 0
+            # shellcheck disable=2154
+            run skipped_apache "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+            describe "Cleanup apache2"
+            apt-get purge -y apache2 || true
+            apt-get autoremove -y || true
+        else
+
+            describe "Running failed test with apache2 installed"
+            register_test retvalshouldbe 1
+            # shellcheck disable=2154
+            run failed_apache "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+            describe "Correcting apache2 state - enabling remediation"
+            sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+            "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+            describe "Checking resolved apache2 state"
+            register_test retvalshouldbe 0
+            # shellcheck disable=2154
+            run resolved_apache "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+            describe "Cleanup apache2"
+            apt-get purge -y apache2 || true
+            apt-get autoremove -y || true
+        fi
+    fi
+
+    if [ "$nginx_available" -eq 0 ]; then
+        describe "Prepare non-compliant state - install nginx"
+        DEBIAN_FRONTEND=noninteractive apt-get install -y nginx || true
+
+        # Ensure we can actually create a non-compliant state.
+        if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+            if systemctl >/dev/null 2>&1; then
+                systemctl unmask nginx.service >/dev/null 2>&1 || true
+                systemctl enable nginx.service >/dev/null 2>&1 || true
+                systemctl start nginx.service >/dev/null 2>&1 || true
+            fi
+        fi
+
+        if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+            describe "Unable to create a non-compliant nginx state - skipping remediation path"
+            skip
+            register_test retvalshouldbe 0
+            # shellcheck disable=2154
+            run skipped_nginx "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+            describe "Cleanup nginx"
+            apt-get purge -y nginx || true
+            apt-get autoremove -y || true
+        else
+
+            describe "Running failed test with nginx installed"
+            register_test retvalshouldbe 1
+            # shellcheck disable=2154
+            run failed_nginx "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+            describe "Correcting nginx state - enabling remediation"
+            sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+            "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+            describe "Checking resolved nginx state"
+            register_test retvalshouldbe 0
+            # shellcheck disable=2154
+            run resolved_nginx "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+            describe "Cleanup nginx"
+            apt-get purge -y nginx || true
+            apt-get autoremove -y || true
+        fi
+    fi
 }

--- a/tests/hardening/disable_nis.sh
+++ b/tests/hardening/disable_nis.sh
@@ -1,16 +1,55 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show ypserv 2>/dev/null | grep -q '^Package: ypserv$'; then
+        describe "ypserv package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install ypserv"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ypserv || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask ypserv.service >/dev/null 2>&1 || true
+            systemctl enable ypserv.service >/dev/null 2>&1 || true
+            systemctl start ypserv.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant ypserv state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y ypserv || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    # Service control may not be available in container test env; package purge path is expected.
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y ypserv || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_print_server.sh
+++ b/tests/hardening/disable_print_server.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show cups 2>/dev/null | grep -q '^Package: cups$'; then
+        describe "cups package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install cups"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y cups || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask cups.socket cups.service >/dev/null 2>&1 || true
+            systemctl enable cups.socket cups.service >/dev/null 2>&1 || true
+            systemctl start cups.socket cups.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant cups state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y cups || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y cups || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_rsync.sh
+++ b/tests/hardening/disable_rsync.sh
@@ -1,11 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show rsync 2>/dev/null | grep -q '^Package: rsync$'; then
+        describe "rsync package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    # TODO fill comprehensive tests
+    describe "Prepare non-compliant state - install rsync"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y rsync || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask rsync.service >/dev/null 2>&1 || true
+            systemctl enable rsync.service >/dev/null 2>&1 || true
+            systemctl start rsync.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant rsync state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y rsync || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y rsync || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_samba.sh
+++ b/tests/hardening/disable_samba.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show samba 2>/dev/null | grep -q '^Package: samba$'; then
+        describe "samba package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install samba"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y samba || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask smbd.service >/dev/null 2>&1 || true
+            systemctl enable smbd.service >/dev/null 2>&1 || true
+            systemctl start smbd.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant samba state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y samba || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y samba || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_snmp_server.sh
+++ b/tests/hardening/disable_snmp_server.sh
@@ -1,16 +1,55 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show snmpd 2>/dev/null | grep -q '^Package: snmpd$'; then
+        describe "snmpd package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install snmpd"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y snmpd || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask snmpd.service >/dev/null 2>&1 || true
+            systemctl enable snmpd.service >/dev/null 2>&1 || true
+            systemctl start snmpd.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant snmpd state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y snmpd || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y snmpd || true
+    apt-get autoremove -y || true
+    rm -rf /var/lib/snmp || true
 }

--- a/tests/hardening/disable_xinetd.sh
+++ b/tests/hardening/disable_xinetd.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show xinetd 2>/dev/null | grep -q '^Package: xinetd$'; then
+        describe "xinetd package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install xinetd"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y xinetd || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask xinetd.service >/dev/null 2>&1 || true
+            systemctl enable xinetd.service >/dev/null 2>&1 || true
+            systemctl start xinetd.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant xinetd state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y xinetd || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y xinetd || true
+    apt-get autoremove -y || true
 }


### PR DESCRIPTION
They all are built on the same pattern, like the one used in rpcbind_is_disabled.sh

bin/hardening/disable_nis.sh -> 2.1.10
bin/hardening/disable_print_server.sh -> 2.1.11
bin/hardening/disable_rsync.sh -> 2.1.13
bin/hardening/disable_samba.sh -> 2.1.14
bin/hardening/disable_snmp_server.sh -> 2.1.15
bin/hardening/disable_http_proxy.sh -> 2.1.17
bin/hardening/disable_http_server.sh -> 2.1.18
bin/hardening/disable_xinetd.sh -> 2.1.19
bin/hardening/disable_automounting.sh -> 2.1.1
bin/hardening/disable_avahi_server.sh -> 2.1.2