### PR TITLE
update some scripts to debian 12 CIS standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ For checks that are intentionally **manual remediation only** (script `apply()` 
 - Restore modified config files at end of test
 - In tests, if `${script}` (or other harness vars) is used in local variable assignments, add `# shellcheck disable=2154` immediately above those lines.
 - If non-compliant state cannot be created (config absent), use `skip` + `register_test`/`run` inside the conditional block
+- For dependency-aware package/service tests, first try to force a non-compliant state by installing the package and, when `systemctl` is available, unmasking/enabling/starting the related units. If the audit still returns compliant, skip the remediation path cleanly instead of forcing `retvalshouldbe 1`.
 - Do not use `mount`/`remount` in containers; skip those tests with a container check
 - For scripts interacting with audit runtime (auditctl/augenrules), check `auditctl -s` availability and skip if not present.
 - For scripts interacting with systemd, use `is_systemctl_running` and skip when systemd is not running.

--- a/bin/hardening/disable_dhcp.sh
+++ b/bin/hardening/disable_dhcp.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure DHCP Server is not enabled (Scored)
+# Ensure dhcp server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,107 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure DHCP server is not enabled."
+DESCRIPTION="Ensure dhcp server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=dhcp
 
-PACKAGES='udhcpd isc-dhcp-server'
+PACKAGE='isc-dhcp-server'
+SERVICE4='isc-dhcp-server.service'
+SERVICE6='isc-dhcp-server6.service'
+
+# Global state (0=true/success, 1=false/failure)
+DHCP_PKG_INSTALLED=1
+DHCP_PKG_IS_DEPENDENCY=1
+DHCP_SERVICE4_ENABLED=1
+DHCP_SERVICE4_ACTIVE=1
+DHCP_SERVICE6_ENABLED=1
+DHCP_SERVICE6_ACTIVE=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    DHCP_PKG_INSTALLED=1
+    DHCP_PKG_IS_DEPENDENCY=1
+    DHCP_SERVICE4_ENABLED=1
+    DHCP_SERVICE4_ACTIVE=1
+    DHCP_SERVICE6_ENABLED=1
+    DHCP_SERVICE6_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DHCP_PKG_INSTALLED=0
+    else
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        DHCP_PKG_IS_DEPENDENCY=0
+    fi
+
+    if [ "$DHCP_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+        return
+    fi
+
+    is_service_enabled "$SERVICE4"
+    if [ "$FNRET" -eq 0 ]; then
+        DHCP_SERVICE4_ENABLED=0
+        crit "$SERVICE4 is enabled"
+    fi
+
+    is_service_active "$SERVICE4"
+    if [ "$FNRET" -eq 0 ]; then
+        DHCP_SERVICE4_ACTIVE=0
+        crit "$SERVICE4 is active"
+    fi
+
+    is_service_enabled "$SERVICE6"
+    if [ "$FNRET" -eq 0 ]; then
+        DHCP_SERVICE6_ENABLED=0
+        crit "$SERVICE6 is enabled"
+    fi
+
+    is_service_active "$SERVICE6"
+    if [ "$FNRET" -eq 0 ]; then
+        DHCP_SERVICE6_ACTIVE=0
+        crit "$SERVICE6 is active"
+    fi
+
+    if [ "$DHCP_SERVICE4_ENABLED" -ne 0 ] && [ "$DHCP_SERVICE4_ACTIVE" -ne 0 ] &&
+        [ "$DHCP_SERVICE6_ENABLED" -ne 0 ] && [ "$DHCP_SERVICE6_ACTIVE" -ne 0 ]; then
+        ok "$PACKAGE is used as a dependency and $SERVICE4/$SERVICE6 are not enabled/active"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$DHCP_PKG_INSTALLED" -ne 0 ]; then
+        ok "$PACKAGE is not installed"
+        return
+    fi
+
+    if [ "$DHCP_PKG_IS_DEPENDENCY" -ne 0 ]; then
+        info "$PACKAGE is installed and not a dependency, removing it"
+        apt-get purge "$PACKAGE" -y
+        apt-get autoremove -y
+        return
+    fi
+
+    is_systemctl_running
+    if [ "$FNRET" -ne 0 ]; then
+        warn "systemd not running, cannot stop/mask $SERVICE4 and $SERVICE6"
+        return
+    fi
+
+    if [ "$DHCP_SERVICE4_ENABLED" -eq 0 ] || [ "$DHCP_SERVICE4_ACTIVE" -eq 0 ] ||
+        [ "$DHCP_SERVICE6_ENABLED" -eq 0 ] || [ "$DHCP_SERVICE6_ACTIVE" -eq 0 ]; then
+        info "Stopping and masking $SERVICE4 and $SERVICE6"
+        systemctl stop "$SERVICE4" "$SERVICE6" || true
+        systemctl mask "$SERVICE4" "$SERVICE6"
+    else
+        ok "$SERVICE4 and $SERVICE6 already not enabled/active"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_dns_server.sh
+++ b/bin/hardening/disable_dns_server.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure DNS Server is not enabled (Scored)
+# Ensure DNS server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,78 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure Domain Name System (dns) server is not enabled."
+DESCRIPTION="Ensure DNS server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=dns
 
-PACKAGES='bind9 unbound'
+PACKAGE='bind9'
+SERVICE='bind9.service'
+
+# 2 scenario here:
+# - bind9 is a dependency for another package -> disable the service
+# - bind9 is not a dependency for another package -> remove the package
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
+    PACKAGE_INSTALLED=1
+    PACKAGE_IS_DEPENDENCY=1
+    SERVICE_ENABLED=1
+    SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_INSTALLED=0
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_IS_DEPENDENCY=0
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ENABLED=0
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ACTIVE=0
+    fi
+
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        active=1
+        if [ "$SERVICE_ENABLED" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is enabled"
         fi
-    done
+
+        if [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is active"
+        fi
+
+        if [ "$active" -eq 1 ]; then
+            ok "$PACKAGE is not used"
+        fi
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency, removing it"
+        apt_remove "$PACKAGE" -y
+        apt-get autoremove -y
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        if [ "$SERVICE_ENABLED" -eq 0 ] || [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE"
+            systemctl stop "$SERVICE"
+            systemctl mask "$SERVICE"
         fi
-    done
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_ftp.sh
+++ b/bin/hardening/disable_ftp.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure FTP Server is not enabled (Scored)
+# Ensure ftp server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,37 +15,78 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure File Transfer Protocol (ftp) is not enabled."
+DESCRIPTION="Ensure ftp server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=ftp
 
-# Based on aptitude search '~Pftp-server'
-PACKAGES='ftpd ftpd-ssl heimdal-servers inetutils-ftpd krb5-ftpd muddleftpd proftpd-basic pure-ftpd pure-ftpd-ldap pure-ftpd-mysql pure-ftpd-postgresql twoftpd-run vsftpd wzdftpd'
+PACKAGE='vsftpd'
+SERVICE='vsftpd.service'
+
+# 2 scenario here:
+# - vsftpd is a dependency for another package -> disable the service
+# - vsftpd is not a dependency for another package -> remove the package
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
+    PACKAGE_INSTALLED=1
+    PACKAGE_IS_DEPENDENCY=1
+    SERVICE_ENABLED=1
+    SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_INSTALLED=0
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_IS_DEPENDENCY=0
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ENABLED=0
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ACTIVE=0
+    fi
+
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        active=1
+        if [ "$SERVICE_ENABLED" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is enabled"
         fi
-    done
+
+        if [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is active"
+        fi
+
+        if [ "$active" -eq 1 ]; then
+            ok "$PACKAGE is not used"
+        fi
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency, removing it"
+        apt_remove "$PACKAGE" -y
+        apt-get autoremove -y
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        if [ "$SERVICE_ENABLED" -eq 0 ] || [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE"
+            systemctl stop "$SERVICE"
+            systemctl mask "$SERVICE"
         fi
-    done
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_ldap.sh
+++ b/bin/hardening/disable_ldap.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure LDAP server is not enabled (Scored)
+# Ensure ldap server services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,78 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure LDAP is not enabled."
+DESCRIPTION="Ensure LDAP server services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=ldap
 
-PACKAGES='slapd'
+PACKAGE='slapd'
+SERVICE='slapd.service'
+
+# 2 scenario here:
+# - slapd is a dependency for another package -> disable the service
+# - slapd is not a dependency for another package -> remove the package
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
+    PACKAGE_INSTALLED=1
+    PACKAGE_IS_DEPENDENCY=1
+    SERVICE_ENABLED=1
+    SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_INSTALLED=0
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_IS_DEPENDENCY=0
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ENABLED=0
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ACTIVE=0
+    fi
+
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        active=1
+        if [ "$SERVICE_ENABLED" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is enabled"
         fi
-    done
+
+        if [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is active"
+        fi
+
+        if [ "$active" -eq 1 ]; then
+            ok "$PACKAGE is not used"
+        fi
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency, removing it"
+        apt_remove "$PACKAGE" -y
+        apt-get autoremove -y
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        if [ "$SERVICE_ENABLED" -eq 0 ] || [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE"
+            systemctl stop "$SERVICE"
+            systemctl mask "$SERVICE"
         fi
-    done
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_nfs_rpc.sh
+++ b/bin/hardening/disable_nfs_rpc.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure NFS and RPC are not enabled (Scored)
+# Ensure network file system services are not in use (Automated)
 #
 
 set -e # One error, it's over
@@ -15,36 +15,78 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=3
 # shellcheck disable=2034
-DESCRIPTION="Ensure Network File System (nfs) and RPC are not enabled."
+DESCRIPTION="Ensure network file system services are not in use."
 # shellcheck disable=2034
 HARDENING_EXCEPTION=nfs
 
-PACKAGES='nfs-kernel-server'
+PACKAGE='nfs-kernel-server'
+SERVICE='nfs-server.service'
+
+# 2 scenario here:
+# - nfs-kernel-server is a dependency for another package -> disable the service
+# - nfs-kernel-server is not a dependency for another package -> remove the package
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed!"
-        else
-            ok "$PACKAGE is absent"
+    PACKAGE_INSTALLED=1
+    PACKAGE_IS_DEPENDENCY=1
+    SERVICE_ENABLED=1
+    SERVICE_ACTIVE=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_INSTALLED=0
+    fi
+
+    is_pkg_a_dependency "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        PACKAGE_IS_DEPENDENCY=0
+    fi
+
+    is_service_enabled "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ENABLED=0
+    fi
+
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ACTIVE=0
+    fi
+
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency"
+
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        active=1
+        if [ "$SERVICE_ENABLED" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is enabled"
         fi
-    done
+
+        if [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is active"
+        fi
+
+        if [ "$active" -eq 1 ]; then
+            ok "$PACKAGE is not used"
+        fi
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed, purging it"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
+    if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
+        crit "$PACKAGE is installed and not a dependency, removing it"
+        apt_remove "$PACKAGE" -y
+        apt-get autoremove -y
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        if [ "$SERVICE_ENABLED" -eq 0 ] || [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE"
+            systemctl stop "$SERVICE"
+            systemctl mask "$SERVICE"
         fi
-    done
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/disable_rsh_client.sh
+++ b/bin/hardening/disable_rsh_client.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Ensure rsh client is not installed (Scored)
+# Ensure rsh client is not installed (Automated)
 #
 
 set -e # One error, it's over
@@ -15,35 +15,35 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=2
 # shellcheck disable=2034
-DESCRIPTION="Ensure rsh client is not installed, Recommended alternative : ssh."
+DESCRIPTION="Ensure rsh client is not installed."
 
-# Based on aptitude search '~Prsh-client', exluding ssh-client OFC
-PACKAGES='rsh-client rsh-redone-client heimdal-clients'
+PACKAGE='rsh-client'
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            crit "$PACKAGE is installed"
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    RSH_CLIENT_INSTALLED=1
+
+    is_pkg_installed "$PACKAGE"
+    if [ "$FNRET" -eq 0 ]; then
+        RSH_CLIENT_INSTALLED=0
+    fi
+
+    if [ "$RSH_CLIENT_INSTALLED" -eq 0 ]; then
+        crit "$PACKAGE is installed"
+    else
+        ok "$PACKAGE is absent"
+    fi
 }
 
 # This function will be called if the script status is on enabled mode
 apply() {
-    for PACKAGE in $PACKAGES; do
-        is_pkg_installed "$PACKAGE"
-        if [ "$FNRET" = 0 ]; then
-            warn "$PACKAGE is installed, purging"
-            apt-get purge "$PACKAGE" -y
-            apt-get autoremove -y
-        else
-            ok "$PACKAGE is absent"
-        fi
-    done
+    if [ "$RSH_CLIENT_INSTALLED" -eq 0 ]; then
+        warn "$PACKAGE is installed, purging"
+        apt_remove "$PACKAGE" -y
+        apt-get autoremove -y
+    else
+        ok "$PACKAGE is absent"
+    fi
 }
 
 # This function will check config parameters required

--- a/bin/hardening/dnsmasq_is_disabled.sh
+++ b/bin/hardening/dnsmasq_is_disabled.sh
@@ -30,6 +30,7 @@ audit() {
     PACKAGE_INSTALLED=1
     PACKAGE_IS_DEPENDENCY=1
     SERVICE_ENABLED=1
+    SERVICE_ACTIVE=1
 
     is_pkg_installed "$PACKAGE"
     if [ "$FNRET" -eq 0 ]; then
@@ -46,10 +47,29 @@ audit() {
         SERVICE_ENABLED=0
     fi
 
+    is_service_active "$SERVICE"
+    if [ "$FNRET" -eq 0 ]; then
+        SERVICE_ACTIVE=0
+    fi
+
     if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
         crit "$PACKAGE is installed and not a dependency"
-    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ] && [ "$SERVICE_ENABLED" -eq 0 ]; then
-        crit "$SERVICE is enabled"
+
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        active=1
+        if [ "$SERVICE_ENABLED" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is enabled"
+        fi
+
+        if [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            active=0
+            crit "$SERVICE is active"
+        fi
+
+        if [ "$active" -eq 1 ]; then
+            ok "$PACKAGE is not in use"
+        fi
     else
         ok "$PACKAGE is not in use"
     fi
@@ -59,12 +79,14 @@ audit() {
 apply() {
     if [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 1 ]; then
         crit "$PACKAGE is installed and not a dependency, removing it"
-        apt-get purge "$PACKAGE" -y
+        apt_remove "$PACKAGE" -y
         apt-get autoremove -y
-    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ] && [ "$SERVICE_ENABLED" -eq 0 ]; then
-        crit "$SERVICE is enabled, i'm going to stop and mask it"
-        systemctl stop "$SERVICE"
-        systemctl mask "$SERVICE"
+    elif [ "$PACKAGE_INSTALLED" -eq 0 ] && [ "$PACKAGE_IS_DEPENDENCY" -eq 0 ]; then
+        if [ "$SERVICE_ENABLED" -eq 0 ] || [ "$SERVICE_ACTIVE" -eq 0 ]; then
+            info "Stopping and masking $SERVICE"
+            systemctl stop "$SERVICE"
+            systemctl mask "$SERVICE"
+        fi
     else
         ok "$PACKAGE is not in use"
     fi

--- a/tests/hardening/disable_dhcp.sh
+++ b/tests/hardening/disable_dhcp.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show isc-dhcp-server >/dev/null 2>&1; then
+        describe "isc-dhcp-server package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install isc-dhcp-server"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y isc-dhcp-server || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if systemctl >/dev/null 2>&1; then
+            systemctl unmask isc-dhcp-server.service isc-dhcp-server6.service >/dev/null 2>&1 || true
+            systemctl enable isc-dhcp-server.service isc-dhcp-server6.service >/dev/null 2>&1 || true
+            systemctl start isc-dhcp-server.service isc-dhcp-server6.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant isc-dhcp-server state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y isc-dhcp-server || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y isc-dhcp-server || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_dns_server.sh
+++ b/tests/hardening/disable_dns_server.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show bind9 >/dev/null 2>&1; then
+        describe "bind9 package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install bind9"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y bind9 || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if is_systemctl_running; then
+            systemctl unmask bind9.service >/dev/null 2>&1 || true
+            systemctl enable bind9.service >/dev/null 2>&1 || true
+            systemctl start bind9.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant bind9 state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y bind9 || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y bind9 || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_ftp.sh
+++ b/tests/hardening/disable_ftp.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show vsftpd >/dev/null 2>&1; then
+        describe "vsftpd package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install vsftpd"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y vsftpd || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if is_systemctl_running; then
+            systemctl unmask vsftpd.service >/dev/null 2>&1 || true
+            systemctl enable vsftpd.service >/dev/null 2>&1 || true
+            systemctl start vsftpd.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant vsftpd state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y vsftpd || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y vsftpd || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_ldap.sh
+++ b/tests/hardening/disable_ldap.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show slapd >/dev/null 2>&1; then
+        describe "slapd package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install slapd"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y slapd || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if is_systemctl_running; then
+            systemctl unmask slapd.service >/dev/null 2>&1 || true
+            systemctl enable slapd.service >/dev/null 2>&1 || true
+            systemctl start slapd.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant slapd state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y slapd || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y slapd || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_nfs_rpc.sh
+++ b/tests/hardening/disable_nfs_rpc.sh
@@ -1,16 +1,54 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show nfs-kernel-server >/dev/null 2>&1; then
+        describe "nfs-kernel-server package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install nfs-kernel-server"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nfs-kernel-server || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if is_systemctl_running; then
+            systemctl unmask nfs-server.service >/dev/null 2>&1 || true
+            systemctl enable nfs-server.service >/dev/null 2>&1 || true
+            systemctl start nfs-server.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant nfs-kernel-server state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y nfs-kernel-server || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y nfs-kernel-server || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/disable_rsh_client.sh
+++ b/tests/hardening/disable_rsh_client.sh
@@ -1,16 +1,33 @@
 # shellcheck shell=bash
 # run-shellcheck
 test_audit() {
-    describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    if ! apt-cache show rsh-client >/dev/null 2>&1; then
+        describe "rsh-client package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    ##################################################################
-    # For this test, we only check that it runs properly on a blank  #
-    # host, and we check root/sudo consistency. But, we don't test   #
-    # the apply function because it can't be automated or it is very #
-    # long to test and not very useful.                              #
-    ##################################################################
+    describe "Prepare non-compliant state - install rsh-client"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y rsh-client || true
+
+    describe "Running on purpose failed test"
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Correcting situation - enabling remediation"
+    sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
+    "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
+
+    describe "Checking resolved state"
+    register_test retvalshouldbe 0
+    # shellcheck disable=2154
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Clean installation"
+    apt-get purge -y rsh-client || true
+    apt-get autoremove -y || true
 }

--- a/tests/hardening/dnsmasq_is_disabled.sh
+++ b/tests/hardening/dnsmasq_is_disabled.sh
@@ -2,35 +2,55 @@
 # run-shellcheck
 test_audit() {
 
-    describe Prepare on purpose failed test
-    apt install -y dnsmasq
-    # running on a container, will can only test the package installation, not the service management
+    if ! apt-cache show dnsmasq >/dev/null 2>&1; then
+        describe "dnsmasq package is unavailable - skipping"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        return
+    fi
 
-    describe Running failed test
+    describe "Prepare non-compliant state - install dnsmasq"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y dnsmasq || true
+
+    # Ensure we can actually create a non-compliant state.
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        if is_systemctl_running; then
+            systemctl unmask dnsmasq.service >/dev/null 2>&1 || true
+            systemctl enable dnsmasq.service >/dev/null 2>&1 || true
+            systemctl start dnsmasq.service >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if "${CIS_CHECKS_DIR}/${script}.sh" --audit-all >/dev/null 2>&1; then
+        describe "Unable to create a non-compliant dnsmasq state - skipping remediation path"
+        skip
+        register_test retvalshouldbe 0
+        # shellcheck disable=2154
+        run skipped "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        describe "Clean installation"
+        apt-get purge -y dnsmasq || true
+        apt-get autoremove -y || true
+        return
+    fi
+
+    describe "Running on purpose failed test"
     register_test retvalshouldbe 1
     # shellcheck disable=2154
     run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
-    describe correcting situation
+    describe "Correcting situation - enabling remediation"
     sed -i 's/audit/enabled/' "${CIS_CONF_DIR}/conf.d/${script}.cfg"
     "${CIS_CHECKS_DIR}/${script}.sh" --apply || true
 
-    describe Checking resolved state
-    register_test retvalshouldbe 0
-    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
-
-    describe Prepare test package dependencies
-    # try to install a package with not much dependencies
-    apt install -y ocserv
-    # running on a container, will can only test the package installation, not the service management
-
-    describe Running successfull test
+    describe "Checking resolved state"
     register_test retvalshouldbe 0
     # shellcheck disable=2154
-    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    run resolved "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
-    describe clean installation
-    apt remove -y ocserv
-    apt autoremove -y
+    describe "Clean installation"
+    apt-get purge -y dnsmasq || true
+    apt-get autoremove -y || true
 
 }


### PR DESCRIPTION
They all are built on the same pattern, like the one used in rpcbind_is_disabled.sh

bin/hardening/disable_dhcp.sh -> 2.1.3
bin/hardening/disable_dns_server.sh -> 2.1.4
bin/hardening/dnsmasq_is_disabled.sh -> 2.1.5
bin/hardening/disable_ftp.sh -> 2.1.6
bin/hardening/disable_ldap.sh -> 2.1.7
bin/hardening/disable_nfs_rpc.sh -> 2.1.9
bin/hardening/disable_rsh_client.sh	-> 2.2.2