### PR TITLE
fix(logfile_sudo): write a validated sudoers.d drop-in instead of editing /etc/sudoers

### DIFF
--- a/bin/hardening/logfile_sudo.sh
+++ b/bin/hardening/logfile_sudo.sh
@@ -19,18 +19,22 @@ DESCRIPTION="Ensure sudo log files exists."
 
 PATTERN="^\s*Defaults\s+logfile=\S+"
 LOGFILE="/var/log/sudo.log"
+SUDO_LOGFILE_DROPIN="/etc/sudoers.d/cis_sudo_logfile"
+
+# 0 = found / compliant, 1 = not found
+SUDO_LOGFILE_FOUND=1
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    FOUND=0
+    SUDO_LOGFILE_FOUND=1
     for f in /etc/{sudoers,sudoers.d/*}; do
         does_pattern_exist_in_file_nocase "$f" "$PATTERN"
         if [ "$FNRET" = 0 ]; then
-            FOUND=1
+            SUDO_LOGFILE_FOUND=0
         fi
     done
 
-    if [[ "$FOUND" = 1 ]]; then
+    if [ "$SUDO_LOGFILE_FOUND" = 0 ]; then
         ok "Defaults log file found in sudoers file"
     else
         crit "Defaults log file not found in sudoers files"
@@ -38,19 +42,20 @@ audit() {
 }
 # This function will be called if the script status is on enabled mode
 apply() {
-    FOUND=0
-    for f in /etc/{sudoers,sudoers.d/*}; do
-        does_pattern_exist_in_file_nocase "$f" "$PATTERN"
-        if [ "$FNRET" = 0 ]; then
-            FOUND=1
-        fi
-    done
-
-    if [[ "$FOUND" = 1 ]]; then
+    if [ "$SUDO_LOGFILE_FOUND" = 0 ]; then
         ok "Defaults log file found in sudoers file"
     else
         warn "Defaults log file not found in sudoers files, fixing"
-        add_line_file_before_pattern /etc/sudoers "Defaults        logfile=\"$LOGFILE\"" "# Host alias specification"
+        local l_tmpfile
+        l_tmpfile=$(mktemp)
+        echo "Defaults        logfile=\"$LOGFILE\"" >"$l_tmpfile"
+        if visudo -c -f "$l_tmpfile" >/dev/null 2>&1; then
+            install -m 0440 -o root -g root "$l_tmpfile" "$SUDO_LOGFILE_DROPIN"
+            ok "Created $SUDO_LOGFILE_DROPIN"
+        else
+            crit "Generated sudoers snippet failed validation, not installing"
+        fi
+        rm -f "$l_tmpfile"
     fi
 }
 


### PR DESCRIPTION
## Problem

`bin/hardening/logfile_sudo.sh` remediates by editing `/etc/sudoers` in place:

```sh
add_line_file_before_pattern /etc/sudoers "Defaults        logfile=\"$LOGFILE\"" "# Host alias specification"
```

`add_line_file_before_pattern` is `backup_file` followed by a raw `sed -i`, with no validation of the result. Two concerns:

**1. No `visudo -c` before or after.** A malformed `/etc/sudoers` costs all privilege escalation on the host. That is a severe worst case for a recommendation about *logging*, and `sudo` itself refuses to run against a file it cannot parse — so the failure mode is not recoverable through `sudo`.

**2. The anchor is not guaranteed to exist.** `# Host alias specification` is a comment from the stock Debian `sudoers`. On a host where it has been removed or customised, the `sed` matches nothing, the file is unchanged, and `apply()` reports success anyway — a silent no-op.

## The fix

Write `/etc/sudoers.d/cis_sudo_logfile`, validate it with `visudo -c -f` before installing, and install it `0440 root:root`. If validation fails nothing is installed and the script reports `crit`.

`/etc/sudoers` is never touched, so there is no path by which this check can damage sudo.

This does not weaken the recommendation. `audit()` already scans `/etc/{sudoers,sudoers.d/*}`:

```sh
for f in /etc/{sudoers,sudoers.d/*}; do
```

so a drop-in has always been an accepted compliant state — `apply()` was simply not producing one. The change aligns `apply()` with semantics `audit()` already had.

## Also included

Per `AGENTS.md` ("Never duplicate logic — use global variables set in `audit()`" and the unique-global-prefix rule), `apply()` no longer repeats the detection loop and the global is renamed `FOUND` → `SUDO_LOGFILE_FOUND`. Its polarity now follows the documented `0 = true / success` convention. Happy to split this out if you'd rather keep the PR to the security fix alone.

## Verification

Applied the equivalent change by hand on a Debian 13 (trixie) host: `visudo -c` reports all files parse, `sudo` continues to work, `/var/log/sudo.log` is created and written, and the check moves from `[ KO ]` to `[ OK ]`.

I was not able to run `shellcheck`/`shfmt` locally; `bash -n` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)