### PR TITLE
fix(utils): only append mount options to the options field in fstab

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -610,12 +610,23 @@ add_option_to_fstab() {
     local PARTITION=$1
     local OPTION=$2
     debug "Setting $OPTION for $PARTITION in fstab"
+    # A fstab entry is <device> <mount point> <type> <options> <dump> <pass>.
+    # Anchor on the first four fields so the option is only ever appended to
+    # the options field, and never to a filesystem type that happens to hold
+    # a comma. For example :
+    # /dev/sda9       /home           ext4         auto,acl,errors=remount-ro         0  2
+    # /dev/sda9       /home           ext4         auto,acl,errors=remount-ro,nodev   0  2
+    # /dev/cdrom      /media/cdrom0   udf,iso9660  user,noauto                        0  0
+    # /dev/cdrom      /media/cdrom0   udf,iso9660  user,noauto,noexec                 0  0
+    if grep -E "^[[:space:]]*[^#[:space:]]+[[:space:]]+${PARTITION}[[:space:]]" /etc/fstab |
+        awk '{ print "," $4 "," }' | grep -q ",${OPTION},"; then
+        debug "$OPTION is already set for $PARTITION in fstab"
+        return
+    fi
     backup_file "/etc/fstab"
-    # For example :
-    # /dev/sda9       /home           ext4  auto,acl,errors=remount-ro  0       2
-    # /dev/sda9       /home           ext4  auto,acl,errors=remount-ro,nodev  0       2
-    debug "Sed command :  sed -ie \"s;\(.*\)\(\s*\)\s\($PARTITION\)\s\(\s*\)\(\w*\)\(\s*\)\(\w*\)*;\1\2 \3 \4\5\6\7,$OPTION;\" /etc/fstab"
-    sed -ie "s;\(.*\)\(\s*\)\s\($PARTITION\)\s\(\s*\)\(\w*\)\(\s*\)\(\w*\)*;\1\2 \3 \4\5\6\7,$OPTION;" /etc/fstab
+    local FSTAB_ENTRY="^([[:space:]]*[^#[:space:]]+[[:space:]]+${PARTITION}[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+)"
+    debug "Sed command :  sed -i -E \"s;${FSTAB_ENTRY};\\1,${OPTION};\" /etc/fstab"
+    sed -i -E "s;${FSTAB_ENTRY};\1,${OPTION};" /etc/fstab
 }
 
 remount_partition() {


### PR DESCRIPTION
## The bug

`add_option_to_fstab()` in `lib/utils.sh` appends the new mount option using:

```sh
sed -ie "s;\(.*\)\(\s*\)\s\($PARTITION\)\s\(\s*\)\(\w*\)\(\s*\)\(\w*\)*;\1\2 \3 \4\5\6\7,$OPTION;" /etc/fstab
```

`\5` is intended to be the filesystem type and `\7` the options. But `\w` does not match a comma, so on a **multi-value filesystem type** `\5` stops at the first comma and the option is appended there — inside the *type* field, not the options field.

A stock removable-media entry is exactly that case. Running `--apply` on `removable_device_noexec` (or the `nodev`/`nosuid` variants) rewrites:

```
/dev/cdrom      /media/cdrom0   udf,iso9660  user,noauto        0       0
```

into:

```
/dev/cdrom      /media/cdrom0   udf,noexec,iso9660  user,noauto        0       0
```

`noexec` is now a filesystem type. The entry no longer mounts, and the check still reports failure because the option never reached field 4.

Reproduced on a copy of a real `/etc/fstab` (nothing mounted):

```console
$ PARTITION='/media\S*'; OPTION='noexec'
$ sed -ie "s;\(.*\)\(\s*\)\s\($PARTITION\)\s\(\s*\)\(\w*\)\(\s*\)\(\w*\)*;\1\2 \3 \4\5\6\7,$OPTION;" fstab.test
$ grep cdrom fstab.test
/dev/cdrom      /media/cdrom0   udf,noexec,iso9660  user,noauto        0       0
$ ls fstab.test*
fstab.test  fstab.teste
```

## The fix

Anchor the substitution on the first four whitespace-separated fields, so the option can only ever be appended to the end of the options field and the device, mount point, filesystem type and dump/pass fields are left untouched.

Two smaller fixes in the same function, both visible in the transcript above:

- **`sed -ie` was parsed as `-i` with backup suffix `e`**, silently leaving a copy of the pre-hardening fstab at `/etc/fstabe`. On a hardened host that is a world-readable stale copy of a file the suite otherwise takes care to back up deliberately. Now `sed -i`.
- **Return early if the option is already present**, so repeated `--apply` runs cannot append duplicates.

`PARTITION` keeps its existing regex semantics — `removable_device_*` passes `"/media\S*"` — and is still matched against the mount-point field the same way `is_a_partition()` and `has_mount_option()` do. That ruled out an `awk`-based rewrite: `awk` does not support `\S`.

## Verification

`shellcheck -s bash lib/utils.sh` passes.

The patched function was sourced directly from `lib/utils.sh` (with `/etc/fstab` redirected to a fixture) and exercised over four callers' argument shapes — `/media\S*` + `noexec`, `/tmp` + `nodev`, `/` + `nosuid`, `/boot` + `nodev` — asserting for each that the option lands in field 4, the `udf,iso9660` type is untouched, every entry still has 6 fields, a second call is a no-op, and no stray backup file is created. All pass; each of the four fails the same assertions before the patch.

The fixture covers the two shapes the old regex mishandled: a comma-bearing filesystem type (`udf,iso9660`) and an options field containing `=` (`defaults,size=2G`).

I have not added a test under `tests/hardening/` — the affected behaviour is shared by 25 check scripts rather than belonging to one, and the existing tests skip in containers because they need real mounts. Happy to add one wherever you'd prefer it to live.