### PR TITLE
fix: detect a native nftables ruleset in the firewall policy checks

### DIFF
--- a/bin/hardening/net_fw_default_policy_drop.sh
+++ b/bin/hardening/net_fw_default_policy_drop.sh
@@ -15,40 +15,87 @@ set -u # One variable unset, it's over
 # shellcheck disable=2034
 HARDENING_LEVEL=2
 # shellcheck disable=2034
-DESCRIPTION="Check iptables firewall default policy for DROP on INPUT and FORWARD."
+DESCRIPTION="Check firewall default policy for DROP on INPUT and FORWARD, using nftables or iptables."
 
-PACKAGE="iptables"
+FW_NFT_PKG="nftables"
+FW_NFT_CMD="nft"
+FW_IPT_PKG="iptables"
+FW_IPT_CMD="iptables"
+PACKAGES="$FW_NFT_PKG $FW_IPT_PKG"
 FW_CHAINS="INPUT FORWARD"
 FW_POLICY="DROP"
-FW_CMD="iptables"
 FW_TIMEOUT="10"
+
+NET_FW_INSTALLED=1
+NET_FW_NFT_RULESET=""
+NET_FW_IPT_RULESET=""
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    is_pkg_installed "$PACKAGE"
-    if [ "$FNRET" != 0 ]; then
-        crit "$PACKAGE is not installed!"
-    else
-        ipt=$($SUDO_CMD "$FW_CMD" -w "$FW_TIMEOUT" -nL 2>/dev/null || true)
-        if [[ -z "$ipt" ]]; then
-            crit "Empty return from $FW_CMD command. Aborting..."
-            return
-        fi
-        for chain in $FW_CHAINS; do
+    is_pkg_installed "$FW_NFT_PKG"
+    if [ "$FNRET" = 0 ]; then
+        NET_FW_INSTALLED=0
+        NET_FW_NFT_RULESET=$($SUDO_CMD "$FW_NFT_CMD" list ruleset 2>/dev/null || true)
+    fi
+
+    is_pkg_installed "$FW_IPT_PKG"
+    if [ "$FNRET" = 0 ]; then
+        NET_FW_INSTALLED=0
+        NET_FW_IPT_RULESET=$($SUDO_CMD "$FW_IPT_CMD" -nL -w "$FW_TIMEOUT" 2>/dev/null || true)
+    fi
+
+    if [ "$NET_FW_INSTALLED" -ne 0 ]; then
+        crit "None of the following firewall packages are installed: $PACKAGES"
+        return
+    fi
+
+    if [ -z "$NET_FW_NFT_RULESET" ] && [ -z "$NET_FW_IPT_RULESET" ]; then
+        crit "No firewall rule at all, so no chain has $FW_POLICY as its default policy."
+        return
+    fi
+
+    local chain hook regex reason found policies
+    for chain in $FW_CHAINS; do
+        hook=${chain,,}
+        found=1
+        reason=""
+
+        if [ -n "$NET_FW_IPT_RULESET" ]; then
             regex="Chain $chain \(policy ([A-Z]+)\)"
             # previous line will capture actual policy
-            if [[ "$ipt" =~ $regex ]]; then
-                actual_policy=${BASH_REMATCH[1]}
-                if [[ "$actual_policy" = "$FW_POLICY" ]]; then
-                    ok "Policy correctly set to $FW_POLICY for chain $chain"
+            if [[ "$NET_FW_IPT_RULESET" =~ $regex ]]; then
+                if [ "${BASH_REMATCH[1]}" = "$FW_POLICY" ]; then
+                    found=0
+                    ok "Policy correctly set to $FW_POLICY for chain $chain (iptables)"
                 else
-                    crit "Policy set to $actual_policy for chain $chain, should be ${FW_POLICY}."
+                    reason="Policy set to ${BASH_REMATCH[1]} for chain $chain (iptables), should be ${FW_POLICY}."
                 fi
             else
-                crit "Unable to find chain $chain"
+                reason="Unable to find chain $chain (iptables)"
             fi
-        done
-    fi
+        fi
+
+        # A native nftables ruleset is invisible to iptables, so look at it too.
+        # An accept verdict does not end the traversal of a hook, so any base
+        # chain whose policy is DROP is enough to deny the packet.
+        if [ "$found" -ne 0 ] && [ -n "$NET_FW_NFT_RULESET" ]; then
+            policies=$(nft_ip_hook_policies "$hook" <<<"$NET_FW_NFT_RULESET" | tr '\n' ' ')
+            policies=${policies% }
+            if [[ " $policies " == *" $FW_POLICY "* ]]; then
+                found=0
+                ok "Policy correctly set to $FW_POLICY for chain $chain (nftables)"
+            elif [ -n "$policies" ] && [ -z "$reason" ]; then
+                reason="Policy set to $policies for chain $chain (nftables), should be ${FW_POLICY}."
+            fi
+        fi
+
+        if [ "$found" -ne 0 ]; then
+            if [ -z "$reason" ]; then
+                reason="No base chain registered on hook $hook has $FW_POLICY as its default policy."
+            fi
+            crit "$reason"
+        fi
+    done
 }
 
 # This function will be called if the script status is on enabled mode

--- a/bin/hardening/nftables_default_deny_policy.sh
+++ b/bin/hardening/nftables_default_deny_policy.sh
@@ -23,21 +23,24 @@ audit() {
     OUTPUT_CHAIN_DROP=1
     FORWARD_CHAIN_DROP=1
 
-    if $SUDO_CMD nft list ruleset 2>/dev/null | grep "hook input.*policy drop"; then
+    local ruleset
+    ruleset=$($SUDO_CMD nft list ruleset 2>/dev/null || true)
+
+    if nft_ip_hook_policies input <<<"$ruleset" | grep -qx 'DROP'; then
         INPUT_CHAIN_DROP=0
         ok "nft base 'input' chain has 'drop' has default policy"
     else
         crit "nft base 'input' chain does not have 'drop' has default policy"
     fi
 
-    if $SUDO_CMD nft list ruleset 2>/dev/null | grep 'hook output.*policy drop'; then
+    if nft_ip_hook_policies output <<<"$ruleset" | grep -qx 'DROP'; then
         OUTPUT_CHAIN_DROP=0
         ok "nft base 'output' chain has 'drop' has default policy"
     else
         crit "nft base 'output' chain does not have 'drop' has default policy"
     fi
 
-    if $SUDO_CMD nft list ruleset 2>/dev/null | grep 'hook forward.*policy drop'; then
+    if nft_ip_hook_policies forward <<<"$ruleset" | grep -qx 'DROP'; then
         FORWARD_CHAIN_DROP=0
         ok "nft base 'forward' chain has 'drop' has default policy"
     else

--- a/bin/hardening/nftables_established_connections.sh
+++ b/bin/hardening/nftables_established_connections.sh
@@ -22,13 +22,14 @@ NFTABLES_OUTPUT_ALLOWED=""
 
 # This function will be called if the script status is on enabled / audit mode
 audit() {
-    local status
+    local ruleset
+    ruleset=$($SUDO_CMD nft list ruleset 2>/dev/null || true)
 
     for allowed in $NFTABLES_INPUT_ALLOWED; do
         protocol=$(awk -F ':' '{print $1}' <<<"$allowed")
         state=$(awk -F ':' '{print $2}' <<<"$allowed")
 
-        if $SUDO_CMD nft list ruleset 2>/dev/null | awk '/hook input/,/}/' | grep -E "ip protocol $protocol ct state $state accept"; then
+        if nft_ip_base_chains input <<<"$ruleset" | grep -qE "ip protocol $protocol ct state $state accept"; then
             ok "'$protocol' is accepted for state(s) '$state' in nftables 'input'"
         else
             crit "'$protocol' is not accepted for state(s) '$state' in nftables 'input'"
@@ -39,7 +40,7 @@ audit() {
         protocol=$(awk -F ':' '{print $1}' <<<"$allowed")
         state=$(awk -F ':' '{print $2}' <<<"$allowed")
 
-        if $SUDO_CMD nft list ruleset 2>/dev/null | awk '/hook output/,/}/' | grep -E "ip protocol $protocol ct state $state accept"; then
+        if nft_ip_base_chains output <<<"$ruleset" | grep -qE "ip protocol $protocol ct state $state accept"; then
             ok "'$protocol' is accepted for state(s) '$state' in nftables 'output'"
         else
             crit "'$protocol' is not accepted for state(s) '$state' in nftables 'output'"

--- a/bin/hardening/nftables_has_base_chains.sh
+++ b/bin/hardening/nftables_has_base_chains.sh
@@ -23,21 +23,24 @@ audit() {
     OUTPUT_CHAIN=1
     FORWARD_CHAIN=1
 
-    if $SUDO_CMD nft list ruleset 2>/dev/null | grep 'hook input'; then
+    local ruleset
+    ruleset=$($SUDO_CMD nft list ruleset 2>/dev/null || true)
+
+    if [ -n "$(nft_ip_base_chains input <<<"$ruleset")" ]; then
         INPUT_CHAIN=0
         ok "nft base 'input' chain exist"
     else
         crit "nft base 'input' chain does not exist"
     fi
 
-    if $SUDO_CMD nft list ruleset 2>/dev/null | grep 'hook output'; then
+    if [ -n "$(nft_ip_base_chains output <<<"$ruleset")" ]; then
         OUTPUT_CHAIN=0
         ok "nft base 'output' chain exist"
     else
         crit "nft base 'output' chain does not exist"
     fi
 
-    if $SUDO_CMD nft list ruleset 2>/dev/null | grep 'hook forward'; then
+    if [ -n "$(nft_ip_base_chains forward <<<"$ruleset")" ]; then
         FORWARD_CHAIN=0
         ok "nft base 'forward' chain exist"
     else

--- a/bin/hardening/nftables_loopback_is_configured.sh
+++ b/bin/hardening/nftables_loopback_is_configured.sh
@@ -23,14 +23,17 @@ audit() {
     NFTABLES_LOOPBACK_DROP=1
     NFTABLES_IPV6_LOOPBACK_DROP=1
 
-    if nft list ruleset 2>/dev/null | awk '/hook input/,/}/' | grep 'iif "lo" accept'; then
+    local ruleset
+    ruleset=$($SUDO_CMD nft list ruleset 2>/dev/null || true)
+
+    if nft_ip_base_chains input <<<"$ruleset" | grep -q 'iif "lo" accept'; then
         NFTABLES_LOOPBACK=0
         ok "loopback is configured for nftables"
     else
         crit "loopback is not configured for nftables"
     fi
 
-    if nft list ruleset 2>/dev/null | awk '/hook input/,/}/' | grep "ip saddr 127.0.0.1.*drop"; then
+    if nft_ip_base_chains input <<<"$ruleset" | grep -q "ip saddr 127.0.0.1.*drop"; then
         NFTABLES_LOOPBACK_DROP=0
         ok "nftables input loopack traffic is dropped"
     else
@@ -39,7 +42,7 @@ audit() {
 
     is_ipv6_enabled
     if [ "$FNRET" -eq 0 ]; then
-        if nft list ruleset 2>/dev/null | awk '/hook input/,/}/' | grep "ip6 saddr ::1.*drop"; then
+        if nft_ip_base_chains input <<<"$ruleset" | grep -q "ip6 saddr ::1.*drop"; then
             NFTABLES_IPV6_LOOPBACK_DROP=0
             ok "nftables input loopack traffic is dropped"
         else

--- a/bin/hardening/nftables_rules_permanent.sh
+++ b/bin/hardening/nftables_rules_permanent.sh
@@ -33,24 +33,27 @@ audit() {
         NFTABLES_INCLUDE=0
         ok "There is an included file in $NFTABLES_CONF"
 
+        # The included files are written in the same syntax as the output of
+        # `nft list ruleset`, so the same parser applies.
+        local persisted
         # shellcheck disable=2046
-        if [ $(awk '/hook input/,/}/' $(awk '$1 ~ /^\s*include/ { gsub("\"","",$2);print $2 }' $NFTABLES_CONF) | wc -l) -gt 0 ]; then
+        persisted=$(cat $(awk '$1 ~ /^\s*include/ { gsub("\"", "", $2); print $2 }' "$NFTABLES_CONF") 2>/dev/null || true)
+
+        if [ -n "$(nft_ip_base_chains input <<<"$persisted")" ]; then
             NFTABLES_INCLUDE_INPUT=0
             ok "nftables input is configured to be persistent"
         else
             crit "nftables input is not configured to be persistent"
         fi
 
-        # shellcheck disable=2046
-        if [ $(awk '/hook forward/,/}/' $(awk '$1 ~ /^\s*include/ { gsub("\"","",$2);print $2 }' $NFTABLES_CONF) | wc -l) -gt 0 ]; then
+        if [ -n "$(nft_ip_base_chains forward <<<"$persisted")" ]; then
             NFTABLES_INCLUDE_FORWARD=0
             ok "nftables forward is configured to be persistent"
         else
             crit "nftables forward is not configured to be persistent"
         fi
 
-        # shellcheck disable=2046
-        if [ $(awk '/hook output/,/}/' $(awk '$1 ~ /^\s*include/ { gsub("\"","",$2);print $2 }' $NFTABLES_CONF) | wc -l) -gt 0 ]; then
+        if [ -n "$(nft_ip_base_chains output <<<"$persisted")" ]; then
             NFTABLES_INCLUDE_OUTPUT=0
             ok "nftables output is configured to be persistent"
         else

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -770,3 +770,120 @@ manage_service() {
     systemctl "$action" "$service" >/dev/null 2>&1
 
 }
+
+#
+# nftables
+#
+
+# Prints the body of every base chain of type filter registered on the given
+# netfilter hook, reading a ruleset on stdin. Both the block syntax printed by
+# `nft list ruleset` and the flat `add chain ...` syntax accepted by `nft -f`
+# are understood, since a persistent rules file may be written either way.
+#
+# Only the families that carry IP traffic are kept. nftables reuses the input,
+# output and forward hook names in the bridge and arp families for a packet
+# path that carries neither routed nor locally delivered IP traffic, so a
+# policy or a rule found there tells nothing about how the host filters IP.
+#
+# Blocks are delimited by counting braces rather than by stopping at the first
+# closing one, because a rule may hold a brace of its own, as in
+# `tcp dport { 22, 80 } accept`.
+nft_ip_base_chains() {
+    local hook=$1
+    awk -v hook="$hook" '
+        # nft only omits the family for the implicit "ip" one, in which case
+        # the word read here is already the table name.
+        function family(word) {
+            return (word ~ /^(ip|ip6|inet|arp|bridge|netdev)$/) ? word : "ip"
+        }
+        function carries_ip(fam) {
+            return (fam == "ip" || fam == "ip6" || fam == "inet")
+        }
+        {
+            tmp = $0
+            opened = gsub(/[{]/, "&", tmp)
+            closed = gsub(/[}]/, "&", tmp)
+            newdepth = depth + opened - closed
+
+            if (!in_chain) {
+                if (depth == 0 && $1 == "table") {
+                    table_is_ip = carries_ip(family($2))
+                } else if (depth == 0 && $2 == "chain" &&
+                    ($1 == "add" || $1 == "create")) {
+                    # add chain [family] <table> <name> { ... }
+                    in_chain = 1
+                    outer = 0
+                    chain_is_ip = carries_ip(family($3))
+                } else if (depth == 1 && $1 == "chain") {
+                    in_chain = 1
+                    outer = 1
+                    chain_is_ip = table_is_ip
+                }
+                if (in_chain) {
+                    buf = ""
+                    keep = 0
+                }
+            }
+
+            if (in_chain) {
+                if (chain_is_ip && $0 ~ /type[ \t]+filter[ \t]+hook[ \t]/) {
+                    for (i = 1; i < NF; i++) {
+                        if ($i == "hook" && $(i + 1) == hook) {
+                            keep = 1
+                        }
+                    }
+                }
+                buf = buf $0 "\n"
+                if (newdepth <= outer) {
+                    if (keep) {
+                        printf "%s", buf
+                    }
+                    in_chain = 0
+                    buf = ""
+                    keep = 0
+                }
+            }
+
+            depth = newdepth
+        }
+    '
+}
+
+# Prints, one per line and uppercased, the default policy of every base chain
+# retained by nft_ip_base_chains for the given hook, reading a ruleset on
+# stdin.
+#
+# An accept verdict does not end the traversal of a hook, so a packet still
+# meets the policy of the other base chains registered on it: a single chain
+# set to drop is enough to deny.
+nft_ip_hook_policies() {
+    local hook=$1
+    nft_ip_base_chains "$hook" | awk '
+        function flush() {
+            if (seen) {
+                print toupper(policy)
+            }
+        }
+        # A base chain declares its type before its policy, so this line opens
+        # the record of a new chain.
+        /type[ \t]+filter[ \t]+hook[ \t]/ {
+            flush()
+            seen = 1
+            # A base chain declared without a policy defaults to accept.
+            policy = "accept"
+        }
+        # The policy may sit on the declaration line or on one of its own.
+        seen {
+            for (i = 1; i < NF; i++) {
+                if ($i == "policy") {
+                    found = $(i + 1)
+                    gsub(/;/, "", found)
+                    policy = found
+                }
+            }
+        }
+        END {
+            flush()
+        }
+    ' | sort -u
+}

--- a/tests/hardening/net_fw_default_policy_drop.sh
+++ b/tests/hardening/net_fw_default_policy_drop.sh
@@ -2,9 +2,71 @@
 # run-shellcheck
 test_audit() {
     describe Running on blank host
-    register_test retvalshouldbe 0
-    dismiss_count_for_test
-    # Do not run any check, iptables do not work in a docker
-    #run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
-    # TODO fill comprehensive tests
+    register_test retvalshouldbe 1
+    # shellcheck disable=2154
+    run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+    describe "Installing nftables for tests"
+    apt-get update >/dev/null 2>&1 || true
+    DEBIAN_FRONTEND='noninteractive' apt-get install -y nftables >/dev/null 2>&1 || {
+        skip "Cannot install nftables, skipping tests"
+        return
+    }
+
+    # Reading and writing a ruleset needs CAP_NET_ADMIN, which the test
+    # container does not always have.
+    if nft list ruleset >/dev/null 2>&1; then
+        # Chain the setup commands so that a partial ruleset never reaches the
+        # assertions, and delete the tables on every path out: the rest of the
+        # suite runs in this very container, with no rule accepting established
+        # traffic.
+        if nft add table inet cis_test &&
+            nft add chain inet cis_test input '{ type filter hook input priority 0 ; policy accept ; }' &&
+            nft add chain inet cis_test forward '{ type filter hook forward priority 0 ; policy accept ; }'; then
+
+            describe Creating a permissive nftables ruleset
+            register_test retvalshouldbe 1
+            register_test contain "should be DROP"
+            # shellcheck disable=2154
+            run nftaccept "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
+            # The bridge family reuses the input and forward hook names for a
+            # packet path that carries no routed nor locally delivered IP
+            # traffic, so its policy must not be taken for an IP one.
+            describe Adding a bridge ruleset set to drop, IP traffic still unfiltered
+            if nft add table bridge cis_test &&
+                nft add chain bridge cis_test input '{ type filter hook input priority 0 ; policy drop ; }' &&
+                nft add chain bridge cis_test forward '{ type filter hook forward priority 0 ; policy drop ; }'; then
+                register_test retvalshouldbe 1
+                register_test contain "should be DROP"
+                # shellcheck disable=2154
+                run nftbridge "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+            else
+                skip "cannot create a bridge table, skipping the bridge family check"
+            fi
+
+            describe Setting the nftables default policy to drop
+            if nft chain inet cis_test input '{ policy drop ; }' &&
+                nft chain inet cis_test forward '{ policy drop ; }'; then
+                register_test retvalshouldbe 0
+                register_test contain "nftables"
+                # shellcheck disable=2154
+                run nftdrop "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+            else
+                skip "cannot set the default policy to drop, skipping"
+            fi
+        else
+            skip "cannot create the test ruleset, skipping ruleset checks"
+        fi
+
+        describe Removing the test ruleset
+        nft delete table inet cis_test >/dev/null 2>&1 || true
+        nft delete table bridge cis_test >/dev/null 2>&1 || true
+    else
+        skip "no netfilter access in this environment, skipping ruleset checks"
+    fi
+
+    describe Cleaning up
+    apt-get remove -y nftables >/dev/null 2>&1 || true
+    apt-get autoremove -y >/dev/null 2>&1 || true
 }

--- a/tests/hardening/nftables_default_deny_policy.sh
+++ b/tests/hardening/nftables_default_deny_policy.sh
@@ -10,6 +10,44 @@ test_audit() {
     # shellcheck disable=2154
     run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
+    # Reading and writing a ruleset needs CAP_NET_ADMIN, which the test
+    # container does not always have.
+    if nft list ruleset >/dev/null 2>&1; then
+        # The bridge family reuses the input, output and forward hook names for
+        # a packet path that carries no IP traffic, so its policy says nothing
+        # about how the host filters IP.
+        if nft add table bridge cis_test &&
+            nft add chain bridge cis_test input '{ type filter hook input priority 0 ; policy drop ; }' &&
+            nft add chain bridge cis_test output '{ type filter hook output priority 0 ; policy drop ; }' &&
+            nft add chain bridge cis_test forward '{ type filter hook forward priority 0 ; policy drop ; }'; then
+            describe Running with a bridge ruleset set to drop and no IP one
+            register_test retvalshouldbe 1
+            register_test contain "does not have 'drop'"
+            # shellcheck disable=2154
+            run bridgeonly "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        else
+            skip "cannot create a bridge table, skipping the bridge family check"
+        fi
+
+        if nft add table inet cis_test &&
+            nft add chain inet cis_test input '{ type filter hook input priority 0 ; policy drop ; }' &&
+            nft add chain inet cis_test output '{ type filter hook output priority 0 ; policy drop ; }' &&
+            nft add chain inet cis_test forward '{ type filter hook forward priority 0 ; policy drop ; }'; then
+            describe Running with an IP ruleset set to drop
+            register_test retvalshouldbe 0
+            # shellcheck disable=2154
+            run ipdrop "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        else
+            skip "cannot create an inet table, skipping the compliant case"
+        fi
+
+        describe Removing the test ruleset
+        nft delete table bridge cis_test >/dev/null 2>&1 || true
+        nft delete table inet cis_test >/dev/null 2>&1 || true
+    else
+        skip "no netfilter access in this environment, skipping ruleset checks"
+    fi
+
     describe clean test
     apt remove -y nftables
 

--- a/tests/hardening/nftables_has_base_chains.sh
+++ b/tests/hardening/nftables_has_base_chains.sh
@@ -10,6 +10,43 @@ test_audit() {
     # shellcheck disable=2154
     run blank "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
+    # Reading and writing a ruleset needs CAP_NET_ADMIN, which the test
+    # container does not always have.
+    if nft list ruleset >/dev/null 2>&1; then
+        # A base chain in the bridge family filters no IP traffic, so it must
+        # not be taken for the base chain the recommendation asks for.
+        if nft add table bridge cis_test &&
+            nft add chain bridge cis_test input '{ type filter hook input priority 0 ; }' &&
+            nft add chain bridge cis_test output '{ type filter hook output priority 0 ; }' &&
+            nft add chain bridge cis_test forward '{ type filter hook forward priority 0 ; }'; then
+            describe Running with bridge base chains and no IP one
+            register_test retvalshouldbe 1
+            register_test contain "does not exist"
+            # shellcheck disable=2154
+            run bridgeonly "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        else
+            skip "cannot create a bridge table, skipping the bridge family check"
+        fi
+
+        if nft add table inet cis_test &&
+            nft add chain inet cis_test input '{ type filter hook input priority 0 ; }' &&
+            nft add chain inet cis_test output '{ type filter hook output priority 0 ; }' &&
+            nft add chain inet cis_test forward '{ type filter hook forward priority 0 ; }'; then
+            describe Running with IP base chains
+            register_test retvalshouldbe 0
+            # shellcheck disable=2154
+            run ipchains "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+        else
+            skip "cannot create an inet table, skipping the compliant case"
+        fi
+
+        describe Removing the test ruleset
+        nft delete table bridge cis_test >/dev/null 2>&1 || true
+        nft delete table inet cis_test >/dev/null 2>&1 || true
+    else
+        skip "no netfilter access in this environment, skipping ruleset checks"
+    fi
+
     describe clean test
     apt remove -y nftables
 }

--- a/tests/hardening/nftables_rules_permanent.sh
+++ b/tests/hardening/nftables_rules_permanent.sh
@@ -21,14 +21,44 @@ test_audit() {
     register_test retvalshouldbe 1
     run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
+    # Base chains of the bridge family filter no IP traffic, so persisting
+    # them is not what the recommendation asks for.
+    describe Running failed 'only bridge chains persisted'
+    cat >/etc/nftables.rules <<'EOF'
+table bridge cis_test {
+	chain input {
+		type filter hook input priority 0;
+	}
+	chain output {
+		type filter hook output priority 0;
+	}
+	chain forward {
+		type filter hook forward priority 0;
+	}
+}
+EOF
+    register_test retvalshouldbe 1
+    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+
     describe Fixing final situation
-    echo 'hook input' >/etc/nftables.rules
-    echo 'hook output' >>/etc/nftables.rules
-    echo 'hook forward' >>/etc/nftables.rules
+    cat >/etc/nftables.rules <<'EOF'
+table inet cis_test {
+	chain input {
+		type filter hook input priority 0;
+		tcp dport { 22, 80 } accept
+	}
+	chain output {
+		type filter hook output priority 0;
+	}
+	chain forward {
+		type filter hook forward priority 0;
+	}
+}
+EOF
 
     describe Running success
     register_test retvalshouldbe 0
-    run failed "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
+    run success "${CIS_CHECKS_DIR}/${script}.sh" --audit-all
 
     describe clean test
     rm -f /etc/nftables.conf /etc/nftables.rules


### PR DESCRIPTION
## Problem

`net_fw_default_policy_drop` (3.5.4.1.1) only read the iptables chains. A host that filters with nftables and does not have the `iptables` package installed at all was reported as having no default `DROP` policy, even with `policy drop` set on both the `input` and `forward` hooks.

While fixing it, three parsing defects showed up in the other nftables checks, which matched hook names with `grep 'hook input'` and `awk '/hook input/,/}/'`:

- **The bridge and arp families were counted as IP filtering.** nftables reuses the `input`, `output` and `forward` hook names in those families for a packet path that carries neither routed nor locally delivered IP traffic. A host whose IP traffic was not filtered at all could pass on the strength of a bridge policy.
- **A policy declared on a line of its own was missed.** Only the `type filter hook ...` line was scanned, so the valid form below was read as the implicit `accept`, failing a compliant host:
  ```
  chain input {
      type filter hook input priority 0;
      policy drop;
  }
  ```
- **The chain body stopped at the first closing brace.** A rule holding a brace of its own, such as `tcp dport { 22, 80 } accept`, truncated the body, hiding the rules that followed from `nftables_loopback_is_configured` and `nftables_established_connections`.

## Change

Two helpers in `lib/utils.sh`, `nft_ip_base_chains` and `nft_ip_hook_policies`, now do the parsing for all six checks. They keep only the `ip`, `ip6` and `inet` families, count braces to delimit a chain, treat a base chain declared without a policy as `accept`, and also understand the flat `add chain ...` syntax a hand-written persistent rules file may use.

For `net_fw_default_policy_drop`, a chain is compliant as soon as one of the two backends denies: an `accept` verdict does not end the traversal of a hook, so a single base chain set to `drop` is enough. Each ruleset is now read once per audit instead of once per assertion.

The addition to `lib/utils.sh` is purely additive, so no other script is affected.

## Tests

`tests/hardening/nftables_rules_permanent.sh` was asserting on a file containing the literal lines `hook input` / `hook output` / `hook forward`, which only ever passed because of the `awk` range. It now uses a real ruleset, plus a bridge-only case that must fail.

`net_fw_default_policy_drop`, `nftables_default_deny_policy` and `nftables_has_base_chains` gained cases covering a bridge-only ruleset and a compliant IP one. They are guarded on `nft list ruleset` succeeding, since reading and writing a ruleset needs `CAP_NET_ADMIN`, which the test container does not have — they skip in CI and were run locally with the capability granted, on debian11, debian12 and debian13.